### PR TITLE
fix: 修复 ARouter 首次启动路由注册时序

### DIFF
--- a/crates/shield-core/src/dex_packer/route_scanner.rs
+++ b/crates/shield-core/src/dex_packer/route_scanner.rs
@@ -3,6 +3,11 @@ use std::fs;
 use std::path::Path;
 
 const AROUTER_ROUTES_PREFIX: &str = "com/alibaba/android/arouter/routes/";
+const AROUTER_REGISTRY_PREFIXES: [&str; 3] = [
+    "ARouter$$Root$$",
+    "ARouter$$Providers$$",
+    "ARouter$$Interceptors$$",
+];
 
 /// 扫描 DEX 目录，提取所有 ARouter 路由表类的全限定名。
 /// 解析 DEX header 的 class_defs 段，不依赖任何运行时 API。
@@ -19,7 +24,7 @@ pub fn scan_arouter_routes(dex_dir: &Path) -> Result<Vec<String>> {
     for path in &dex_paths {
         let data = fs::read(path)?;
         for name in parse_dex_class_names(&data)? {
-            if name.starts_with(AROUTER_ROUTES_PREFIX) {
+            if is_arouter_registry_class(&name) {
                 let java_name = name.replace('/', ".");
                 routes.push(java_name);
             }
@@ -29,6 +34,17 @@ pub fn scan_arouter_routes(dex_dir: &Path) -> Result<Vec<String>> {
     routes.sort();
     routes.dedup();
     Ok(routes)
+}
+
+fn is_arouter_registry_class(name: &str) -> bool {
+    let Some(simple_name) = name.strip_prefix(AROUTER_ROUTES_PREFIX) else {
+        return false;
+    };
+    AROUTER_REGISTRY_PREFIXES.iter().any(|prefix| {
+        simple_name
+            .strip_prefix(prefix)
+            .is_some_and(|module_name| !module_name.is_empty() && !module_name.contains('$'))
+    })
 }
 
 /// 解析 DEX 文件，提取所有类的描述符（内部格式，如 "Lcom/foo/Bar;"）
@@ -121,4 +137,28 @@ fn u32_le(data: &[u8], offset: usize) -> u32 {
         data[offset + 2],
         data[offset + 3],
     ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_arouter_registry_class;
+
+    #[test]
+    fn 只接受_arouter_可注册入口类() {
+        assert!(is_arouter_registry_class(
+            "com/alibaba/android/arouter/routes/ARouter$$Root$$featurehome"
+        ));
+        assert!(is_arouter_registry_class(
+            "com/alibaba/android/arouter/routes/ARouter$$Providers$$arouterapi"
+        ));
+        assert!(is_arouter_registry_class(
+            "com/alibaba/android/arouter/routes/ARouter$$Interceptors$$app"
+        ));
+        assert!(!is_arouter_registry_class(
+            "com/alibaba/android/arouter/routes/ARouter$$Group$$home"
+        ));
+        assert!(!is_arouter_registry_class(
+            "com/alibaba/android/arouter/routes/ARouter$$Root$$featurehome$1"
+        ));
+    }
 }

--- a/docs/design/internals.md
+++ b/docs/design/internals.md
@@ -60,8 +60,8 @@
 │     └─ makeRealApp() → 真实 Application.attach()               │
 │  ② StubApp.onCreate()                                          │
 │     ├─ replaceAppReferences()                                   │
-│     ├─ realApp.onCreate()                                       │
-│     └─ ARouterCompat.injectARouterRouteMap()（按需）            │
+│     ├─ ARouterCompat.prepareARouterRouteMap()（按需）           │
+│     └─ realApp.onCreate()                                       │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -334,9 +334,9 @@ StubApp.onCreate()
     │         替换 ActivityThread.mAllApplications 列表中的引用
     │         替换 LoadedApk.mApplication
     │
-    ├─[7] realApp.onCreate()
+    ├─[7] ARouterCompat.prepareARouterRouteMap(this)（按需）
     │
-    └─[8] ARouterCompat.injectARouterRouteMap(this)（按需）
+    └─[8] realApp.onCreate()
 ```
 
 ### 5.2 JNI 接口
@@ -407,8 +407,10 @@ addDexPath.invoke(pathList, dexFile.getAbsolutePath(), optDir);
 
 | 方式 | 检测标志 | 处理 |
 |------|---------|------|
-| arouter-register Gradle plugin | `ARouter$$Root$$xxx` 在壳 DEX 中 | 已通过 plugin 静态注入，跳过补注册 |
-| 运行时扫描 | 无上述类 | 静态扫描 DEX，找到所有路由表类，逐一反射调用 `loadInto()` |
+| arouter-register Gradle plugin | `LogisticsCenter.registerByPlugin = true` | 已通过 plugin 静态注入，跳过补注册 |
+| 运行时扫描 | `registerByPlugin = false` | 加固阶段只收集 `Root`、`Providers`、`Interceptors` 注册入口；壳在真实 Application 启动前调用 `LogisticsCenter.register()` 并设置完成标志 |
+
+补注册必须发生在真实 `Application.onCreate()` 之前。ARouter 1.5.1 的 `ARouter.init()` 会在 `LogisticsCenter.init()` 后立即执行 `_ARouter.afterInit()`，此时就会查找并缓存 `InterceptorService`；如果等宿主初始化完成后再补路由表，缓存字段已经是 `null`，后续普通路由跳转会触发空指针。
 
 ---
 
@@ -508,6 +510,16 @@ addDexPath.invoke(pathList, dexFile.getAbsolutePath(), optDir);
 - **问题**：`getSignatureSha256` 仅被 JNI Native 调用，R8 无法感知，判定为死代码删除
 - **修复**：`Ld` 改为 `-keep class ... { *; }` 全保留
 - **教训**：任何被 JNI 调用的类，必须用 `{ *; }` 全保留，不能逐条列举
+
+---
+
+### Bug 9：ARouter 运行期扫描补注册过晚 ✅ 已修复
+
+- **位置**：`ARouterCompat.java`、`StubApp.java`、`route_scanner.rs`
+- **问题**：壳在真实 `Application.onCreate()` 返回后才补注册路由表。ARouter 1.5.1 已在 `ARouter.init()` 内缓存空的 `InterceptorService`，导致首次安装或清除数据后路由跳转空指针；覆盖安装可能因旧缓存暂时正常。
+- **修复**：在真实 Application 启动前预注册 `Root`、`Providers`、`Interceptors` 三类入口，并仅在成功注册后设置 `registerByPlugin`；排除 `Group` 和内部类等无效扫描结果。
+- **验证**：用户多模块 Demo 的未加固基线、加固后首次安装、清除数据后重启均通过同一套真机端到端测试，覆盖两次跨模块跳转和四种参数注入。
+- **教训**：第三方框架若在初始化过程中缓存服务实例，兼容注入必须发生在其初始化入口之前，事后补齐注册表无法修复已缓存的空状态。
 
 ---
 

--- a/docs/process/roadmap.md
+++ b/docs/process/roadmap.md
@@ -123,6 +123,27 @@
 
 ---
 
+### ARouter 运行期扫描在首次安装后路由失败
+
+| 项 | 内容 |
+|----|------|
+| **优先级** | 高 |
+| **状态** | 已完成 |
+| **涉及文件** | `crates/shield-core/src/dex_packer/route_scanner.rs`、`shield-stub/src/main/java/dev/mocika/shield/loader/ARouterCompat.java`、`StubApp.java` |
+
+**现象**：未启用 `arouter-register` 的 ARouter 1.5.1 应用，加固后首次安装或清除应用数据后路由跳转出现 `InterceptorService.doInterceptions(...)` 空指针；保留旧缓存的覆盖安装可能暂时正常。
+
+**根因**：壳在真实 `Application.onCreate()` 返回后才补注册路由表，但 ARouter 已在 `ARouter.init()` 内查找并缓存空的 `InterceptorService`。事后补注册 Warehouse 无法回填该静态字段。
+
+**最终修复方案**：
+
+1. 在真实 Application 启动前读取加固阶段生成的路由清单并调用 `LogisticsCenter.register()`。
+2. 至少成功注册一项后设置 `registerByPlugin`，使 ARouter 跳过无法发现加密 DEX 的运行期扫描。
+3. 扫描清单只保留 `Root`、`Providers`、`Interceptors` 三类入口，排除 `Group` 和内部类。
+4. 使用用户提供的多模块 Demo 真机验证原始基线、加固后首次安装和清除数据后三条路径，跨模块跳转及四类参数注入全部通过。
+
+---
+
 ### 证书对比任务异常时 fail-open
 
 | 项 | 内容 |

--- a/shield-stub/src/main/java/dev/mocika/shield/loader/ARouterCompat.java
+++ b/shield-stub/src/main/java/dev/mocika/shield/loader/ARouterCompat.java
@@ -19,17 +19,16 @@ public class ARouterCompat {
     /**
      * 从 assets/arouter_routes.txt 读取路由表类名并注册到 ARouter Warehouse。
      * 路由表由 shield-cli 加固时静态扫描 DEX 生成，不依赖 DexFile API，兼容 API 24-34。
-     * 必须在 ARouter.init() 执行完毕后调用。
+     * 必须在宿主 Application.onCreate() 之前调用，确保 ARouter.init() 能初始化内置服务。
      */
-    public static void injectARouterRouteMap(Context context) {
+    public static void prepareARouterRouteMap(Context context) {
         try {
             Class<?> logisticsCenterClass = Class.forName(
                     "com.alibaba.android.arouter.core.LogisticsCenter");
 
-            // arouter-register plugin 编译时注入后会将 registerByPlugin 置为 true，无需再补注册
+            java.lang.reflect.Field registerByPlugin = null;
             try {
-                java.lang.reflect.Field registerByPlugin =
-                        logisticsCenterClass.getDeclaredField("registerByPlugin");
+                registerByPlugin = logisticsCenterClass.getDeclaredField("registerByPlugin");
                 registerByPlugin.setAccessible(true);
                 if ((boolean) registerByPlugin.get(null)) {
                     return;
@@ -46,12 +45,19 @@ public class ARouterCompat {
             Method registerMethod = logisticsCenterClass.getDeclaredMethod("register", String.class);
             registerMethod.setAccessible(true);
 
+            int registeredCount = 0;
             for (String className : routeClassNames) {
                 try {
                     registerMethod.invoke(null, className);
+                    registeredCount++;
                 } catch (Exception e) {
                     Log.w(TAG, "  注册路由类失败: " + className, e);
                 }
+            }
+
+            // 告知 LogisticsCenter 路由表已预注册，避免首次安装时再次扫描壳 DEX。
+            if (registerByPlugin != null && registeredCount > 0) {
+                registerByPlugin.setBoolean(null, true);
             }
 
         } catch (ClassNotFoundException ignored) {

--- a/shield-stub/src/main/java/dev/mocika/shield/loader/StubApp.java
+++ b/shield-stub/src/main/java/dev/mocika/shield/loader/StubApp.java
@@ -39,8 +39,8 @@ public class StubApp extends Application {
         super.onCreate();
         if (realApp == null) return;
         replaceAppReferences(realApp);
+        ARouterCompat.prepareARouterRouteMap(this);
         realApp.onCreate();
-        ARouterCompat.injectARouterRouteMap(this);
     }
 
     @Override


### PR DESCRIPTION
## 问题

未启用 `arouter-register` 的 ARouter 1.5.1 应用，加固后首次安装或清除数据后，运行期扫描无法发现加密 DEX 中的路由表。现有兼容逻辑又在宿主 `Application.onCreate()` 返回后才补注册，此时 ARouter 已经缓存空的 `InterceptorService`。

## 修复

- 在真实 Application 启动前预注册 ARouter 路由入口
- 成功注册后设置 `registerByPlugin`，跳过壳 DEX 的无效运行期扫描
- 扫描清单只保留 `Root`、`Providers`、`Interceptors`
- 排除 `Group` 和内部类等无效注册项
- 补充根因、时序和真机验证文档

## 验证

- 用户提供的多模块 Demo 原始 APK 端到端测试通过
- 修复版加固 APK 首次安装端到端测试通过
- 清除应用数据后再次测试通过
- 跨模块两次跳转及 String、Int、Boolean、Parcelable 注入全部通过
- 核心 74 项测试通过
- shield-stub 四 ABI 构建通过
- 日志无 `InterceptorService` 空指针、路由注册失败或崩溃