### PR TITLE
chore: 发布 1.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "mocika-shield"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "chacha20poly1305",
  "dunce",
@@ -2168,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "mocikashield"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "chacha20poly1305",
  "hkdf",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "shield-cli"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "shield-core"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "anyhow",
  "chacha20poly1305",

--- a/apps/shield-cli/Cargo.toml
+++ b/apps/shield-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shield-cli"
-version = "1.2.5"
+version = "1.2.6"
 edition = "2021"
 authors = ["MocikaDev"]
 license = "MIT"

--- a/apps/shield-gui/package-lock.json
+++ b/apps/shield-gui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mocika-shield-gui",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mocika-shield-gui",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.19",
         "@radix-ui/react-label": "^2.1.11",

--- a/apps/shield-gui/package.json
+++ b/apps/shield-gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocika-shield-gui",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/shield-gui/src-tauri/Cargo.toml
+++ b/apps/shield-gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mocika-shield"
-version = "1.2.5"
+version = "1.2.6"
 edition = "2021"
 publish = false
 description = "Mocika Shield APK 加固工具桌面 GUI"

--- a/apps/shield-gui/src-tauri/tauri.conf.json
+++ b/apps/shield-gui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MocikaShield",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "identifier": "dev.mocika.shield-gui",
   "build": {
     "beforeDevCommand": "npm run dev -- --host 127.0.0.1",

--- a/apps/shield-gui/src/hooks/use-about-page.ts
+++ b/apps/shield-gui/src/hooks/use-about-page.ts
@@ -10,7 +10,7 @@ type AppInfo = {
 };
 
 const defaultAppInfo: AppInfo = {
-  version: "1.2.5",
+  version: "1.2.6",
   git_hash: "dev",
   build_date: "unknown",
 };

--- a/crates/shield-core/Cargo.toml
+++ b/crates/shield-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shield-core"
-version = "1.2.5"
+version = "1.2.6"
 edition = "2021"
 authors = ["MocikaDev"]
 license = "MIT"

--- a/shield-stub/src/main/rust/Cargo.toml
+++ b/shield-stub/src/main/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mocikashield"
-version = "1.2.5"
+version = "1.2.6"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
## 变更内容

- 将核心库、命令行、Android 壳与桌面端版本统一更新为 1.2.6
- 同步 Rust 与前端锁文件
- 同步桌面端关于页面的回退版本号

## 发布重点

- 包含 ARouter 首次启动路由注册时序修复
- GitHub Release 继续仅发布桌面 GUI 安装包

## 本地验证

- `cargo check --workspace`
- `make test`（核心库 74 项测试通过）
- `npm run build --prefix apps/shield-gui`
- `make build-stub`（四架构壳及 resources.zip 构建通过）
- `make build-gui`（发布模式 GUI 后端构建通过）
- `git diff --check`