### PR TITLE
test: 增加端到端加固回归测试

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,9 @@ jobs:
           path: shield-stub/build/outputs/resources/resources.zip
           if-no-files-found: error
 
+      - name: 运行端到端加固回归测试
+        run: bash tests/scripts/run-protect-e2e.sh
+
   release-readiness:
     name: 发布前检查
     if: github.event_name == 'workflow_dispatch'

--- a/docs/process/roadmap.md
+++ b/docs/process/roadmap.md
@@ -506,10 +506,11 @@ shield sign    -i input.apk -o output.apk --ks keystore.jks --ks-pass <pass> --k
 
 - `protect` 命令：XML Manifest 解析、Adler32 校验、ABI 检测、DEX 处理相关单元测试
 - `sign` 命令：KeystoreType 自动识别、alias 解析单元测试
+- 自有最小 Android 测试夹具覆盖“编译 → 原始签名 → 加固 → 再签名 → 产物结构与签名验证”的无设备端到端链路
 
 **仍缺失**：
 
-- `protect` 端到端 smoke test（输入 APK → 输出结构验证）
+- Android 模拟器自动安装、首次启动与清除数据后的运行时回归
 - JNI 降级路径测试（native 失败时 Java 反射是否正确接管）
 
 ---

--- a/docs/process/test-checklist.md
+++ b/docs/process/test-checklist.md
@@ -2,6 +2,17 @@
 
 本文档记录发布前和关键改动后的手动回归检查项。自动化测试不能覆盖桌面安装包、系统 Java 环境、真实 APK 安装启动等场景时，按本清单补足验证。
 
+## 自动端到端加固回归
+
+修改加固、签名、Manifest、DEXB、壳资源或 ZIP 对齐链路后执行：
+
+```bash
+make build-stub
+bash tests/scripts/run-protect-e2e.sh
+```
+
+脚本使用项目自有最小 Android 测试夹具，验证从源码 APK 到已签名加固产物的完整无设备链路。CI 的“Android 壳构建”任务也会执行该测试。
+
 ## 使用时机
 
 - 发布 `rc` 或稳定版本前

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,12 @@
+# 端到端回归测试
+
+`fixtures/android-smoke-app` 是项目自有的最小 Android 测试夹具，只负责提供包含自定义 `Application` 和启动 `Activity` 的稳定输入 APK，不承载产品示例或业务功能。
+
+`scripts/run-protect-e2e.sh` 负责无设备回归链路：编译测试 APK、临时生成测试证书、签名原始 APK、执行加固、再次签名，并验证签名、MSHD 块、壳 Native 库和 `check-apk` 结果。
+
+```bash
+make build-stub
+bash tests/scripts/run-protect-e2e.sh
+```
+
+测试证书只在系统临时目录中生成，脚本退出时自动清理，不向仓库提交任何私钥。日常 CI 不启动模拟器；首次安装、清除数据、框架路由和真实运行时加载仍按发布测试清单在真机完成。

--- a/tests/fixtures/android-smoke-app/app/build.gradle.kts
+++ b/tests/fixtures/android-smoke-app/app/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    id("com.android.application")
+}
+
+android {
+    namespace = "dev.mocika.shield.smoke"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "dev.mocika.shield.smoke"
+        minSdk = 21
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}

--- a/tests/fixtures/android-smoke-app/app/src/main/AndroidManifest.xml
+++ b/tests/fixtures/android-smoke-app/app/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:name=".SmokeApplication"
+        android:allowBackup="false"
+        android:label="@string/app_name">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/tests/fixtures/android-smoke-app/app/src/main/java/dev/mocika/shield/smoke/MainActivity.java
+++ b/tests/fixtures/android-smoke-app/app/src/main/java/dev/mocika/shield/smoke/MainActivity.java
@@ -1,0 +1,15 @@
+package dev.mocika.shield.smoke;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.widget.TextView;
+
+public final class MainActivity extends Activity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        TextView content = new TextView(this);
+        content.setText("Mocika Shield 端到端测试");
+        setContentView(content);
+    }
+}

--- a/tests/fixtures/android-smoke-app/app/src/main/java/dev/mocika/shield/smoke/SmokeApplication.java
+++ b/tests/fixtures/android-smoke-app/app/src/main/java/dev/mocika/shield/smoke/SmokeApplication.java
@@ -1,0 +1,10 @@
+package dev.mocika.shield.smoke;
+
+import android.app.Application;
+
+public final class SmokeApplication extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+    }
+}

--- a/tests/fixtures/android-smoke-app/app/src/main/res/values/strings.xml
+++ b/tests/fixtures/android-smoke-app/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Mocika Shield Smoke</string>
+</resources>

--- a/tests/fixtures/android-smoke-app/build.gradle.kts
+++ b/tests/fixtures/android-smoke-app/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("com.android.application") version "8.13.2" apply false
+}

--- a/tests/fixtures/android-smoke-app/settings.gradle.kts
+++ b/tests/fixtures/android-smoke-app/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "mocika-shield-smoke-app"
+include(":app")

--- a/tests/scripts/run-protect-e2e.sh
+++ b/tests/scripts/run-protect-e2e.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FIXTURE="$ROOT/tests/fixtures/android-smoke-app"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/mocika-protect-e2e.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+for command in java keytool cargo unzip; do
+  command -v "$command" >/dev/null || { echo "缺少命令: $command" >&2; exit 1; }
+done
+
+test -f "$ROOT/shield-stub/build/outputs/resources/resources.zip" || {
+  echo "缺少 resources.zip，请先执行 make build-stub" >&2
+  exit 1
+}
+
+"$ROOT/shield-stub/gradlew" -p "$FIXTURE" :app:assembleRelease --no-daemon
+cargo build --release -p shield-cli --manifest-path "$ROOT/Cargo.toml"
+
+UNSIGNED="$FIXTURE/app/build/outputs/apk/release/app-release-unsigned.apk"
+SIGNED="$WORK/input-signed.apk"
+PROTECTED="$WORK/output-protected.apk"
+FINAL="$WORK/output-protected-signed.apk"
+KEYSTORE="$WORK/smoke.p12"
+PASSWORD="mocika-test-123"
+
+keytool -genkeypair -noprompt -storetype PKCS12 \
+  -keystore "$KEYSTORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
+  -alias smoke -keyalg RSA -keysize 2048 -validity 3650 \
+  -dname "CN=Mocika Shield Smoke, O=MocikaDev, C=CN"
+
+java -jar "$ROOT/tools/apksigner.jar" sign \
+  --ks "$KEYSTORE" --ks-pass "pass:$PASSWORD" --ks-key-alias smoke \
+  --out "$SIGNED" "$UNSIGNED"
+
+"$ROOT/target/release/shield" protect --input "$SIGNED" --output "$PROTECTED"
+
+java -jar "$ROOT/tools/apksigner.jar" sign \
+  --ks "$KEYSTORE" --ks-pass "pass:$PASSWORD" --ks-key-alias smoke \
+  --out "$FINAL" "$PROTECTED"
+java -jar "$ROOT/tools/apksigner.jar" verify --verbose "$FINAL"
+
+CHECK_RESULT="$("$ROOT/target/release/shield" check-apk "$FINAL")"
+printf '%s\n' "$CHECK_RESULT" | grep -q '"already_protected":true'
+printf '%s\n' "$CHECK_RESULT" | grep -q '"is_signed":true'
+
+unzip -p "$FINAL" classes.dex > "$WORK/classes.dex"
+grep -a -q 'MSHD' "$WORK/classes.dex"
+unzip -l "$FINAL" | grep -q 'lib/arm64-v8a/libmocikashield.so'
+
+echo "端到端加固回归测试通过"


### PR DESCRIPTION
## 变更内容

- 增加项目自有的最小 Android 测试夹具
- 增加“编译、临时签名、加固、再签名、产物验收”的无设备回归脚本
- 验证 APK 签名、MSHD 块、壳 Native 库和 `check-apk` 结果
- 将回归测试接入“Android 壳构建”CI 任务
- 同步路线图、测试说明和发布回归清单

## 边界

- 不向生产 crate 增加测试专用接口
- 测试证书仅在临时目录生成并自动清理
- 日常 CI 不启动模拟器，真机运行仍保留在发布回归清单

## 本地验证

- `bash tests/scripts/run-protect-e2e.sh`
- `cargo fmt --all --check`
- `cargo test -p shield-core`（74 项通过）
- `cargo test -p shield-cli`
- `bash -n tests/scripts/run-protect-e2e.sh`
- `git diff --check`