### PR TITLE
feat: 增加安卓五至六兼容注入路径

### DIFF
--- a/docs/design/internals.md
+++ b/docs/design/internals.md
@@ -377,7 +377,7 @@ f2  ←→  Ld.q(Context ctx, byte[] dexData) → byte[][]
 
 **核心原则：不创建任何中间 ClassLoader，所有 app 类的 defining loader 始终是原始 PathClassLoader。**
 
-优先路径（JNI，不受 hidden API 限制）：
+API 24 及以上优先使用 JNI 路径（不受 hidden API 限制）：
 
 ```rust
 // f1（Ld.p JNI 实现）
@@ -389,7 +389,7 @@ FindClass("dalvik/system/BaseDexClassLoader")
 → CallVoidMethod 调用
 ```
 
-降级路径（Java 反射，`p` 返回 false 时）：
+API 24 及以上的降级路径（Java 反射，`p` 返回 false 时）：
 
 ```java
 Method addDexPath = pathList.getClass().getDeclaredMethod("addDexPath", String.class, File.class);
@@ -399,9 +399,20 @@ addDexPath.invoke(pathList, dexFile.getAbsolutePath(), optDir);
 
 `addDexPath` 内部将 DEX 直接注册到 PathClassLoader（`definingContext`），天然避免 `multiple class loaders` 问题。
 
+API 21～23 没有 `addDexPath(String, File)`，由 `DexInjector` 直接调用系统的 Element 工厂并前插到原 `PathClassLoader`：
+
+| 系统 | Element 工厂 | 参数签名 |
+|------|--------------|----------|
+| API 21～22 | `makeDexElements` | `ArrayList<File>, File, ArrayList<IOException>` |
+| API 23 | `makePathElements` | `List<File>, File, List<IOException>` |
+
+实现按系统版本确定首选方法名，并保留另一个名称作为厂商系统兼容回退。工厂返回的 Element 必须放在壳 Element 之前，确保业务类优先；构造过程中产生的 `dexElementsSuppressedExceptions` 会合并回系统字段并作为加载失败抛出，不允许静默丢失部分 DEX。
+
 **兼容性：**
-- `addDexPath(String, File)` 在 Android 7.0（API 24）~ 15（API 35）均存在
+- Android 5.0～6.0（API 21～23）：Element 工厂注入，已通过 API 21/23 官方 ARM64 模拟器的单 DEX、双 DEX 和应用启动回归，仍需厂商真机与复杂样本验证
+- Android 7.0（API 24）及以上：`addDexPath(String, File)` 注入
 - API 26+ `optimizedDirectory` 参数被忽略（传 null）
+- Android 4.4（API 19～20）：当前 Rust Native 库最低按 API 21 构建，暂不支持
 
 ### 5.4 ARouter 路由表补注册
 

--- a/docs/process/roadmap.md
+++ b/docs/process/roadmap.md
@@ -37,6 +37,26 @@
 
 ## 一、已知缺陷（Bug）
 
+### Android 5.0～6.0 DEX 加载兼容
+
+| 项 | 内容 |
+|----|------|
+| **优先级** | 高 |
+| **状态** | 进行中 |
+| **涉及文件** | `shield-stub`、运行时兼容测试、使用与设计文档 |
+
+**目标**：在不创建第二个 ClassLoader、不改变 DEXB 格式的前提下，将运行时支持范围扩展到 Android 5.0（API 21）及以上。
+
+**实施方案**：
+
+1. API 24 及以上保持现有 JNI `addDexPath` 路径。
+2. API 21～22 反射调用 `makeDexElements`，API 23 反射调用 `makePathElements`。
+3. 所有版本均把解密 DEX Element 前插到原 `PathClassLoader`，保持唯一 defining loader。
+4. 单元测试覆盖版本路由和 Element 顺序；API 21、23 设备覆盖首次启动、清除数据、多 DEX、ARouter 和 Native 库。
+5. Android 4.4（API 19～20）因当前 Rust Native 构建下限和 Dalvik 差异单独评估，不纳入本轮实现。
+
+**完成条件**：API 21 与 API 23 真机或官方模拟器端到端加固产物可安装、冷启动并通过关键功能回归；在此之前只作为测试兼容路径，不更新正式最低支持声明。
+
 ### V2/V3-only APK 预检与加固签名提取不一致
 
 | 项 | 内容 |

--- a/docs/process/test-checklist.md
+++ b/docs/process/test-checklist.md
@@ -87,6 +87,15 @@ bash tests/scripts/run-protect-e2e.sh
 - 输入 APK 与自动签名输出的 `certificate SHA-256 digest` 一致
 - 加固后的 APK 可安装并正常启动
 
+## Android 运行时兼容
+
+- API 21、22 使用 `makeDexElements` 路径，日志包含 `dex-route:elementFactory`
+- API 23 使用 `makePathElements` 路径，日志包含 `dex-route:elementFactory`
+- API 24 及以上继续使用 `addDexPath` 路径，日志包含 `dex-route:addDexPath`
+- API 21、23 分别验证单 DEX、多 DEX、真实 Application、ARouter 和 Native 库加载
+- 同一测试 APK 在 API 21、23、24 设备上完成冷启动、清除数据后首次启动和覆盖安装启动
+- API 19～20 明确拒绝或保持不支持，不将 API 21 构建的 Native 库作为兼容产物交付
+
 ## APK 对齐与 Google Play 兼容
 
 - 加固输出 APK 已执行 ZIP 对齐
@@ -126,6 +135,17 @@ bash tests/scripts/run-protect-e2e.sh
 - 匿名统计接口不可用时，任务日志出现警告且页面明确标记不可用，GitHub 下载统计仍正常生成
 
 ## 关键改动验证记录
+
+### 2026-07-27：Android 5.0～6.0 DEX 注入兼容原型
+
+| 项 | 结果 |
+|----|------|
+| 自动验证 | API 21～22/23 方法路由与 Element 前插单元测试通过；混淆壳构建和端到端加固回归通过 |
+| Android 5.0 | 官方 ARM64 AVD `mocika_api21`，Android 5.0.2（API 21）；单 DEX、双 DEX、首次安装、清除数据后启动和覆盖安装均成功，日志确认 `dex-route:elementFactory api=21` |
+| Android 6.0 | 官方 ARM64 AVD `mocika_api23`，Android 6.0（API 23）；单 DEX、双 DEX、首次安装、清除数据后启动和覆盖安装均成功，日志确认 `dex-route:elementFactory api=23` |
+| 高版本回归 | 一加 ONEPLUS A5000，Android 16（API 36），arm64-v8a；测试 APK 安装和冷启动成功 |
+| 运行时路径 | 日志确认 `dex-route:addDexPath api=36`，进程持续存活，无 DEX 注入或真实 Application 启动异常 |
+| 待验证 | 低 `minSdk` 的 ARouter 与宿主 Native 库样本、Android 5.x/6.0 厂商真机；完成前不调整正式最低支持范围 |
 
 ### 2026-07-20：严格 V2-only APK 签名提取
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -149,10 +149,10 @@ ls -lh input.apk protected.apk
 
 1. 查看日志：
    ```bash
-   adb logcat | grep -E "AndroidRuntime|ax|lx|rx|e[1-4]"
+   adb logcat | grep -E "AndroidRuntime|ax|dx|lx|rx|e[1-4]"
    ```
 
-   当前壳层日志 tag 已做弱特征化处理，常见 tag 为 `ax`（StubApp）、`lx`（Ld）、`rx`（ARouterCompat）。
+   当前壳层日志 tag 已做弱特征化处理，常见 tag 为 `ax`（StubApp）、`dx`（DEX 注入）、`lx`（Ld）、`rx`（ARouterCompat）。
 
 2. 确认未用未签名 APK 加固（必须先签名再加固）：
    ```bash
@@ -167,7 +167,7 @@ ls -lh input.apk protected.apk
    adb shell getprop ro.product.cpu.abi
    ```
 
-4. 确认 Android 版本 ≥ 7.0（API 24）
+4. 正式版本当前按 Android 7.0（API 24）及以上验证；Android 5.0～6.0（API 21～23）的兼容路径已通过官方 ARM64 模拟器基础回归，厂商真机测试产物需确认日志中出现 `dex-route:elementFactory`
 
 ### 能否重复加固？
 

--- a/shield-stub/src/main/java/dev/mocika/shield/loader/ARouterCompat.java
+++ b/shield-stub/src/main/java/dev/mocika/shield/loader/ARouterCompat.java
@@ -18,7 +18,7 @@ public class ARouterCompat {
 
     /**
      * 从 assets/arouter_routes.txt 读取路由表类名并注册到 ARouter Warehouse。
-     * 路由表由 shield-cli 加固时静态扫描 DEX 生成，不依赖 DexFile API，兼容 API 24-34。
+     * 路由表由 shield-cli 加固时静态扫描 DEX 生成，不依赖 DexFile API，兼容 API 21 及以上。
      * 必须在宿主 Application.onCreate() 之前调用，确保 ARouter.init() 能初始化内置服务。
      */
     public static void prepareARouterRouteMap(Context context) {

--- a/shield-stub/src/main/java/dev/mocika/shield/loader/DexInjector.java
+++ b/shield-stub/src/main/java/dev/mocika/shield/loader/DexInjector.java
@@ -1,0 +1,185 @@
+package dev.mocika.shield.loader;
+
+import android.content.Context;
+import android.os.Build;
+import android.util.Log;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+/** 按 Android 版本将解密 DEX 注入应用原有的 PathClassLoader。 */
+final class DexInjector {
+
+    private static final String TAG = "dx";
+
+    private DexInjector() {}
+
+    static void inject(Context context, List<File> dexFiles) throws Exception {
+        ClassLoader classLoader = context.getClassLoader();
+        File optimizedDirectory = Build.VERSION.SDK_INT < 26
+                ? context.getDir("dex_opt", Context.MODE_PRIVATE) : null;
+
+        if (Build.VERSION.SDK_INT >= 24) {
+            Log.i(TAG, "dex-route:addDexPath api=" + Build.VERSION.SDK_INT);
+            injectWithAddDexPath(classLoader, dexFiles, optimizedDirectory);
+            return;
+        }
+        if (Build.VERSION.SDK_INT >= 21) {
+            Log.i(TAG, "dex-route:elementFactory api=" + Build.VERSION.SDK_INT);
+            injectWithElementFactory(classLoader, dexFiles, optimizedDirectory,
+                    factoryMethodNames(Build.VERSION.SDK_INT));
+            return;
+        }
+        throw new UnsupportedOperationException("Android API " + Build.VERSION.SDK_INT
+                + " 暂不支持 DEX 注入");
+    }
+
+    private static void injectWithAddDexPath(ClassLoader classLoader, List<File> dexFiles,
+                                              File optimizedDirectory) throws Exception {
+        String[] dexPaths = new String[dexFiles.size()];
+        for (int i = 0; i < dexFiles.size(); i++) {
+            dexPaths[i] = dexFiles.get(i).getAbsolutePath();
+        }
+        String optimizedPath = optimizedDirectory == null ? "" : optimizedDirectory.getAbsolutePath();
+        if (Ld.p(classLoader, dexPaths, optimizedPath)) {
+            return;
+        }
+
+        Object pathList = findField(classLoader.getClass(), "pathList").get(classLoader);
+        Field elementsField = findField(pathList.getClass(), "dexElements");
+        int oldLength = ((Object[]) elementsField.get(pathList)).length;
+        Method addDexPath = findMethod(pathList.getClass(), "addDexPath", String.class, File.class);
+        for (File dexFile : dexFiles) {
+            addDexPath.invoke(pathList, dexFile.getAbsolutePath(), optimizedDirectory);
+        }
+        moveAppendedElementsToFront(pathList, elementsField, oldLength);
+    }
+
+    private static void injectWithElementFactory(ClassLoader classLoader, List<File> dexFiles,
+                                                  File optimizedDirectory,
+                                                  String[] methodNames) throws Exception {
+        Object pathList = findField(classLoader.getClass(), "pathList").get(classLoader);
+        Field elementsField = findField(pathList.getClass(), "dexElements");
+        ArrayList<File> files = new ArrayList<>(dexFiles);
+        ArrayList<IOException> suppressed = new ArrayList<>();
+        Method factory = findElementFactory(pathList.getClass(), methodNames);
+
+        Object[] injected;
+        try {
+            injected = (Object[]) factory.invoke(pathList, files, optimizedDirectory, suppressed);
+        } catch (InvocationTargetException error) {
+            Throwable cause = error.getCause();
+            if (cause instanceof Exception) throw (Exception) cause;
+            throw error;
+        }
+        if (!suppressed.isEmpty()) {
+            mergeSuppressedExceptions(pathList, suppressed);
+            IOException error = new IOException("构造解密 DEX Element 失败");
+            error.initCause(suppressed.get(0));
+            throw error;
+        }
+        prependElements(pathList, elementsField, injected);
+    }
+
+    static String[] factoryMethodNames(int sdkInt) {
+        return sdkInt >= 23
+                ? new String[]{"makePathElements", "makeDexElements"}
+                : new String[]{"makeDexElements", "makePathElements"};
+    }
+
+    static Object[] prepend(Object[] original, Object[] injected) {
+        Object[] combined = (Object[]) Array.newInstance(
+                original.getClass().getComponentType(), original.length + injected.length);
+        System.arraycopy(injected, 0, combined, 0, injected.length);
+        System.arraycopy(original, 0, combined, injected.length, original.length);
+        return combined;
+    }
+
+    private static void prependElements(Object pathList, Field elementsField, Object[] injected)
+            throws IllegalAccessException {
+        Object[] original = (Object[]) elementsField.get(pathList);
+        elementsField.set(pathList, prepend(original, injected));
+    }
+
+    private static void moveAppendedElementsToFront(Object pathList, Field elementsField,
+                                                     int oldLength) throws IllegalAccessException {
+        Object[] elements = (Object[]) elementsField.get(pathList);
+        int injectedCount = elements.length - oldLength;
+        if (injectedCount <= 0) return;
+        Object[] original = new Object[oldLength];
+        Object[] injected = new Object[injectedCount];
+        System.arraycopy(elements, 0, original, 0, oldLength);
+        System.arraycopy(elements, oldLength, injected, 0, injectedCount);
+        elementsField.set(pathList, prepend(elementsOfSameType(elements, original),
+                elementsOfSameType(elements, injected)));
+    }
+
+    private static Object[] elementsOfSameType(Object[] template, Object[] values) {
+        Object[] result = (Object[]) Array.newInstance(
+                template.getClass().getComponentType(), values.length);
+        System.arraycopy(values, 0, result, 0, values.length);
+        return result;
+    }
+
+    private static Method findElementFactory(Class<?> type, String[] names)
+            throws NoSuchMethodException {
+        for (String name : names) {
+            for (Class<?> current = type; current != null; current = current.getSuperclass()) {
+                for (Method method : current.getDeclaredMethods()) {
+                    Class<?>[] parameters = method.getParameterTypes();
+                    if (method.getName().equals(name)
+                            && parameters.length == 3
+                            && parameters[0].isAssignableFrom(ArrayList.class)
+                            && parameters[1] == File.class
+                            && parameters[2].isAssignableFrom(ArrayList.class)) {
+                        method.setAccessible(true);
+                        return method;
+                    }
+                }
+            }
+        }
+        throw new NoSuchMethodException(names[0]);
+    }
+
+    private static Method findMethod(Class<?> type, String name, Class<?>... parameters)
+            throws NoSuchMethodException {
+        for (Class<?> current = type; current != null; current = current.getSuperclass()) {
+            try {
+                Method method = current.getDeclaredMethod(name, parameters);
+                method.setAccessible(true);
+                return method;
+            } catch (NoSuchMethodException ignored) {}
+        }
+        throw new NoSuchMethodException(name);
+    }
+
+    private static Field findField(Class<?> type, String name) throws NoSuchFieldException {
+        for (Class<?> current = type; current != null; current = current.getSuperclass()) {
+            try {
+                Field field = current.getDeclaredField(name);
+                field.setAccessible(true);
+                return field;
+            } catch (NoSuchFieldException ignored) {}
+        }
+        throw new NoSuchFieldException(name);
+    }
+
+    private static void mergeSuppressedExceptions(Object pathList, List<IOException> added)
+            throws ReflectiveOperationException {
+        Field field = findField(pathList.getClass(), "dexElementsSuppressedExceptions");
+        IOException[] existing = (IOException[]) field.get(pathList);
+        int existingLength = existing == null ? 0 : existing.length;
+        IOException[] combined = new IOException[added.size() + existingLength];
+        added.toArray(combined);
+        if (existing != null) {
+            System.arraycopy(existing, 0, combined, added.size(), existingLength);
+        }
+        field.set(pathList, combined);
+    }
+}

--- a/shield-stub/src/main/java/dev/mocika/shield/loader/StubApp.java
+++ b/shield-stub/src/main/java/dev/mocika/shield/loader/StubApp.java
@@ -8,7 +8,6 @@ import android.util.Log;
 
 import java.io.File;
 import java.lang.ref.WeakReference;
-import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -27,7 +26,7 @@ public class StubApp extends Application {
         try {
             exemptHiddenApi();
             List<File> dexFiles = Ld.extractDexFiles(base);
-            injectDexElements(base, dexFiles);
+            DexInjector.inject(base, dexFiles);
             realApp = makeRealApp(base.getClassLoader(), base);
         } catch (Exception e) {
             throw new RuntimeException("init", e);
@@ -46,63 +45,6 @@ public class StubApp extends Application {
     @Override
     public Context getApplicationContext() {
         return realApp != null ? realApp : super.getApplicationContext();
-    }
-
-    /**
-     * 将落地的 DEX 文件注入原始 PathClassLoader 的 dexElements。
-     *
-     * 优先通过 JNI 路径（Ld.p）完成注入：JNI 访问字段/方法不经过
-     * hidden API 检查，面向 Android 15+ 更健壮。JNI 失败时降级到 Java 反射方案。
-     *
-     * addDexPath 内部将 DEX 直接注册到 PathClassLoader（definingContext），
-     * 整个过程不创建任何中间 ClassLoader，从根源上避免：
-     *   - "multiple class loaders" InternalError（同一 DEX 被多个 loader 注册）
-     *   - InstantiationError（lambda access check 因 defining loader 不一致而失败）
-     */
-    private void injectDexElements(Context base, List<File> dexFiles) throws Exception {
-        ClassLoader pathCl = base.getClassLoader();
-
-        String[] dexPaths = new String[dexFiles.size()];
-        for (int i = 0; i < dexFiles.size(); i++) {
-            dexPaths[i] = dexFiles.get(i).getAbsolutePath();
-        }
-        String optDirPath = (android.os.Build.VERSION.SDK_INT < 26)
-                ? base.getDir("dex_opt", Context.MODE_PRIVATE).getAbsolutePath() : "";
-
-        boolean nativeOk = Ld.p(pathCl, dexPaths, optDirPath);
-        if (!nativeOk) {
-            injectDexElementsJavaFallback(base, pathCl, dexFiles);
-        }
-    }
-
-    private void injectDexElementsJavaFallback(Context base, ClassLoader pathCl, List<File> dexFiles)
-            throws Exception {
-        Field pathListField = findField(pathCl.getClass(), "pathList");
-        pathListField.setAccessible(true);
-        Object pathList = pathListField.get(pathCl);
-
-        Field dexElementsField = findField(pathList.getClass(), "dexElements");
-        dexElementsField.setAccessible(true);
-        int oldLen = ((Object[]) dexElementsField.get(pathList)).length;
-
-        Method addDexPath = findMethod(pathList.getClass(), "addDexPath",
-                String.class, File.class);
-        File optDir = (android.os.Build.VERSION.SDK_INT < 26)
-                ? base.getDir("dex_opt", Context.MODE_PRIVATE) : null;
-
-        for (File dexFile : dexFiles) {
-            addDexPath.invoke(pathList, dexFile.getAbsolutePath(), optDir);
-        }
-
-        Object[] elements = (Object[]) dexElementsField.get(pathList);
-        int injected = elements.length - oldLen;
-        if (injected > 0) {
-            Object[] reordered = (Object[]) Array.newInstance(
-                    elements.getClass().getComponentType(), elements.length);
-            System.arraycopy(elements, oldLen, reordered, 0, injected);
-            System.arraycopy(elements, 0, reordered, injected, oldLen);
-            dexElementsField.set(pathList, reordered);
-        }
     }
 
     private static Method findMethod(Class<?> clazz, String name, Class<?>... params)

--- a/shield-stub/src/test/java/dev/mocika/shield/loader/DexInjectorTest.java
+++ b/shield-stub/src/test/java/dev/mocika/shield/loader/DexInjectorTest.java
@@ -1,0 +1,35 @@
+package dev.mocika.shield.loader;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class DexInjectorTest {
+
+    @Test
+    public void api21和22优先使用makeDexElements() {
+        assertArrayEquals(
+                new String[]{"makeDexElements", "makePathElements"},
+                DexInjector.factoryMethodNames(21));
+        assertArrayEquals(
+                new String[]{"makeDexElements", "makePathElements"},
+                DexInjector.factoryMethodNames(22));
+    }
+
+    @Test
+    public void api23优先使用makePathElements() {
+        assertArrayEquals(
+                new String[]{"makePathElements", "makeDexElements"},
+                DexInjector.factoryMethodNames(23));
+    }
+
+    @Test
+    public void 解密dex元素插入原元素之前() {
+        String[] original = new String[]{"壳"};
+        String[] injected = new String[]{"业务1", "业务2"};
+
+        assertArrayEquals(
+                new String[]{"业务1", "业务2", "壳"},
+                DexInjector.prepend(original, injected));
+    }
+}


### PR DESCRIPTION
## 变更内容

- 将 DEX 注入职责从 `StubApp` 收敛到独立 `DexInjector`
- API 21～22 使用 `makeDexElements` 构造 Element
- API 23 使用 `makePathElements` 构造 Element
- API 24 及以上保持现有 JNI `addDexPath` 路径
- 所有路径继续修改同一个原始 `PathClassLoader`，不创建第二个 ClassLoader
- 增加版本路由、Element 前插测试、运行日志和兼容性文档

## 已完成验证

- Android Lint 与壳单元测试通过
- 混淆壳资源构建和无设备端到端加固回归通过
- Rust 格式、严格 Clippy、核心库 74 项测试及 CLI 测试通过
- Android 5.0.2 / API 21 官方 ARM64 模拟器：单 DEX、双 DEX、首次安装、清除数据启动、覆盖安装通过
- Android 6.0 / API 23 官方 ARM64 模拟器：单 DEX、双 DEX、首次安装、清除数据启动、覆盖安装通过
- Android 16 真机安装和冷启动通过，确认继续走 `addDexPath`
- macOS `.app` 构建通过

## 后续验证

低 `minSdk` 的 ARouter 与宿主 Native 库样本、Android 5.x/6.0 厂商真机尚未覆盖。在完成复杂样本验证前，不调整正式最低支持范围。

关联 Issue：#15