### PR TITLE
准备 v1.2.7-rc.2 预发布版本

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "mocika-shield"
-version = "1.2.7-rc.1"
+version = "1.2.7-rc.2"
 dependencies = [
  "chacha20poly1305",
  "dunce",
@@ -2168,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "mocikashield"
-version = "1.2.7-rc.1"
+version = "1.2.7-rc.2"
 dependencies = [
  "chacha20poly1305",
  "hkdf",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "shield-cli"
-version = "1.2.7-rc.1"
+version = "1.2.7-rc.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "shield-core"
-version = "1.2.7-rc.1"
+version = "1.2.7-rc.2"
 dependencies = [
  "anyhow",
  "chacha20poly1305",

--- a/apps/shield-cli/Cargo.toml
+++ b/apps/shield-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shield-cli"
-version = "1.2.7-rc.1"
+version = "1.2.7-rc.2"
 edition = "2021"
 authors = ["MocikaDev"]
 license = "MIT"

--- a/apps/shield-gui/package-lock.json
+++ b/apps/shield-gui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mocika-shield-gui",
-  "version": "1.2.7-rc.1",
+  "version": "1.2.7-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mocika-shield-gui",
-      "version": "1.2.7-rc.1",
+      "version": "1.2.7-rc.2",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.19",
         "@radix-ui/react-label": "^2.1.11",

--- a/apps/shield-gui/package.json
+++ b/apps/shield-gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocika-shield-gui",
-  "version": "1.2.7-rc.1",
+  "version": "1.2.7-rc.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/shield-gui/src-tauri/Cargo.toml
+++ b/apps/shield-gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mocika-shield"
-version = "1.2.7-rc.1"
+version = "1.2.7-rc.2"
 edition = "2021"
 publish = false
 description = "Mocika Shield APK 加固工具桌面 GUI"

--- a/apps/shield-gui/src-tauri/tauri.conf.json
+++ b/apps/shield-gui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MocikaShield",
-  "version": "1.2.7-rc.1",
+  "version": "1.2.7-rc.2",
   "identifier": "dev.mocika.shield-gui",
   "build": {
     "beforeDevCommand": "npm run dev -- --host 127.0.0.1",

--- a/apps/shield-gui/src/hooks/use-about-page.ts
+++ b/apps/shield-gui/src/hooks/use-about-page.ts
@@ -10,7 +10,7 @@ type AppInfo = {
 };
 
 const defaultAppInfo: AppInfo = {
-  version: "1.2.7-rc.1",
+  version: "1.2.7-rc.2",
   git_hash: "dev",
   build_date: "unknown",
 };

--- a/crates/shield-core/Cargo.toml
+++ b/crates/shield-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shield-core"
-version = "1.2.7-rc.1"
+version = "1.2.7-rc.2"
 edition = "2021"
 authors = ["MocikaDev"]
 license = "MIT"

--- a/shield-stub/src/main/rust/Cargo.toml
+++ b/shield-stub/src/main/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mocikashield"
-version = "1.2.7-rc.1"
+version = "1.2.7-rc.2"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
## 内容

- 将核心库、命令行、Android 壳和桌面应用版本同步为 `1.2.7-rc.2`
- 同步 Rust 与前端锁文件
- 包含已合并的跨加固方案覆盖升级 ARouter 缓存修复

## 验证

- 版本同步脚本执行成功
- Rust 核心与命令行编译检查通过
- 发布前轻量检查通过
- 用户已使用正式证书验证旧爱加密版本覆盖升级到修复候选包正常