### PR TITLE
fix: 修复Windows兼容资源发布构建

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ concurrency:
 
 env:
   ANDROID_NDK_VERSION: 29.0.14206865
+  ANDROID_NDK_API19_VERSION: 25.2.9519653
 
 jobs:
   rust:
@@ -117,7 +118,7 @@ jobs:
           set +o pipefail
           yes | sdkmanager --licenses >/dev/null
           set -o pipefail
-          sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;${ANDROID_NDK_VERSION}"
+          sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;${ANDROID_NDK_VERSION}" "ndk;${ANDROID_NDK_API19_VERSION}"
           echo "ANDROID_NDK_ROOT=${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}" >> "$GITHUB_ENV"
 
       - name: 配置 Rust target 与构建工具
@@ -129,6 +130,7 @@ jobs:
             x86_64-linux-android
           cargo install cargo-ndk --locked
           cargo install tauri-cli --locked
+          rustup toolchain install 1.77.2 --profile minimal --target armv7-linux-androideabi
 
       - name: 安装 GUI 前端依赖
         working-directory: apps/shield-gui
@@ -166,13 +168,14 @@ jobs:
           set +o pipefail
           yes | sdkmanager --licenses >/dev/null
           set -o pipefail
-          sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;${ANDROID_NDK_VERSION}"
+          sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;${ANDROID_NDK_VERSION}" "ndk;${ANDROID_NDK_API19_VERSION}"
           echo "ANDROID_NDK_ROOT=${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}" >> "$GITHUB_ENV"
 
       - name: 配置 Rust Android target
         run: |
           rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
           cargo install cargo-ndk --locked
+          rustup toolchain install 1.77.2 --profile minimal --target armv7-linux-androideabi
 
       - name: 构建 shield-stub
         run: make build-stub
@@ -213,13 +216,14 @@ jobs:
           set +o pipefail
           yes | sdkmanager --licenses >/dev/null
           set -o pipefail
-          sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;${ANDROID_NDK_VERSION}"
+          sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;${ANDROID_NDK_VERSION}" "ndk;${ANDROID_NDK_API19_VERSION}"
           echo "ANDROID_NDK_ROOT=${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}" >> "$GITHUB_ENV"
 
       - name: 配置 Rust Android target
         run: |
           rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
           cargo install cargo-ndk --locked
+          rustup toolchain install 1.77.2 --profile minimal --target armv7-linux-androideabi
 
       - name: 构建 shield-stub
         run: make build-stub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ permissions:
 
 env:
   ANDROID_NDK_VERSION: 29.0.14206865
+  ANDROID_NDK_API19_VERSION: 25.2.9519653
 
 jobs:
   linux-tauri:
@@ -78,7 +79,7 @@ jobs:
           set +o pipefail
           yes | sdkmanager --licenses >/dev/null
           set -o pipefail
-          sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;${ANDROID_NDK_VERSION}"
+          sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;${ANDROID_NDK_VERSION}" "ndk;${ANDROID_NDK_API19_VERSION}"
           echo "ANDROID_NDK_ROOT=${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}" >> "$GITHUB_ENV"
 
       - name: 配置 Rust target 与构建工具
@@ -91,6 +92,7 @@ jobs:
           cargo install cargo-ndk --locked
           cargo install tauri-cli --locked
           cargo install cargo-deb --locked
+          rustup toolchain install 1.77.2 --profile minimal --target armv7-linux-androideabi
 
       - name: 安装 GUI 前端依赖
         working-directory: apps/shield-gui
@@ -151,7 +153,7 @@ jobs:
           set +o pipefail
           yes | sdkmanager --licenses >/dev/null
           set -o pipefail
-          sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;${ANDROID_NDK_VERSION}"
+          sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;${ANDROID_NDK_VERSION}" "ndk;${ANDROID_NDK_API19_VERSION}"
           echo "ANDROID_NDK_ROOT=${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}" >> "$GITHUB_ENV"
 
       - name: 配置 Rust target 与构建工具
@@ -165,6 +167,7 @@ jobs:
             x86_64-linux-android
           cargo install cargo-ndk --locked
           cargo install tauri-cli --locked
+          rustup toolchain install 1.77.2 --profile minimal --target armv7-linux-androideabi
 
       - name: 安装 GUI 前端依赖
         working-directory: apps/shield-gui
@@ -225,8 +228,12 @@ jobs:
         shell: pwsh
         run: |
           1..20 | ForEach-Object { "y" } | sdkmanager --licenses | Out-Null
-          sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;$env:ANDROID_NDK_VERSION"
+          sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;$env:ANDROID_NDK_VERSION" "ndk;$env:ANDROID_NDK_API19_VERSION"
           "ANDROID_NDK_ROOT=$env:ANDROID_HOME\ndk\$env:ANDROID_NDK_VERSION" >> $env:GITHUB_ENV
+
+      - name: 配置 Android 4.4 兼容 Rust 工具链
+        shell: pwsh
+        run: rustup toolchain install 1.77.2 --profile minimal --target armv7-linux-androideabi
 
       - name: 安装 GUI 前端依赖
         working-directory: apps/shield-gui

--- a/docs/ops/environment.md
+++ b/docs/ops/environment.md
@@ -7,7 +7,7 @@
 | Rust | 1.70+ | 含 `rustup` |
 | Java / JDK | 17+ | 必须为完整 JDK，且 `java`、`javac`、`keytool` 均在 PATH |
 | Android SDK | API 21+ | 需要 `ANDROID_HOME` 或 `ANDROID_SDK_ROOT` 环境变量 |
-| Android NDK | 29.0.14206865（必须与此版本一致） | `build.gradle.kts` 硬编码，版本不同需设 `ANDROID_NDK_ROOT` 覆盖 |
+| Android NDK | 29.0.14206865 + 25.2.9519653 | 标准模式使用 r29；Android 4.4 兼容模式的 ARMv7 使用 r25c |
 | cargo-ndk | 最新 | `cargo install cargo-ndk` |
 | Android build-tools | 任意版本含 `d8` | 用于 JAR→DEX 转换 |
 | Tauri CLI | 最新 | 桌面 GUI 构建驱动 |
@@ -94,6 +94,7 @@ rustup default stable-msvc
 # Rust targets
 rustup target add x86_64-pc-windows-msvc   # Windows CLI/GUI
 rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android  # Android 壳
+rustup toolchain install 1.77.2 --profile minimal --target armv7-linux-androideabi  # Android 4.4 兼容壳
 ```
 
 #### 第四步：安装 cargo 工具
@@ -111,7 +112,7 @@ $env:ANDROID_HOME = "$env:USERPROFILE\scoop\apps\android-clt\current"
 [System.Environment]::SetEnvironmentVariable("ANDROID_HOME", $env:ANDROID_HOME, "User")
 
 # 通过 sdkmanager 安装指定版本 NDK
-"y" | sdkmanager "ndk;29.0.14206865"
+"y" | sdkmanager "ndk;29.0.14206865" "ndk;25.2.9519653"
 ```
 
 #### 第六步：安装 Visual Studio Build Tools 2022（必须手动）

--- a/scripts/build-android-api19-resources.sh
+++ b/scripts/build-android-api19-resources.sh
@@ -21,14 +21,19 @@ if [[ -z "$ANDROID_SDK" ]]; then
     exit 1
 fi
 if [[ ! -f "$ANDROID_SDK/ndk/25.2.9519653/source.properties" ]]; then
-    echo "正在安装 Android 4.4 兼容构建所需的 NDK r25c..."
-    sdkmanager "ndk;25.2.9519653"
+    echo "错误：未安装 Android 4.4 兼容构建所需的 NDK r25c（25.2.9519653）"
+    echo '请先执行：sdkmanager "ndk;25.2.9519653"'
+    exit 1
 fi
 if ! rustup run 1.77.2 rustc --version >/dev/null 2>&1; then
-    rustup toolchain install 1.77.2 --profile minimal
+    echo "错误：未安装 Android 4.4 兼容构建所需的 Rust 1.77.2"
+    echo "请先执行：rustup toolchain install 1.77.2 --profile minimal --target armv7-linux-androideabi"
+    exit 1
 fi
 if ! rustup target list --toolchain 1.77.2 --installed | grep -qx armv7-linux-androideabi; then
-    rustup target add --toolchain 1.77.2 armv7-linux-androideabi
+    echo "错误：Rust 1.77.2 未安装 armv7-linux-androideabi target"
+    echo "请先执行：rustup target add --toolchain 1.77.2 armv7-linux-androideabi"
+    exit 1
 fi
 
 for required in "$MAPPING_FILE" "$STANDARD_RESOURCES"; do

--- a/scripts/setup-windows-dev.ps1
+++ b/scripts/setup-windows-dev.ps1
@@ -13,7 +13,8 @@
 #   2. 重新打开终端，让 PATH 生效
 
 param(
-    [string]$NdkVersion = "29.0.14206865"
+    [string]$NdkVersion = "29.0.14206865",
+    [string]$CompatNdkVersion = "25.2.9519653"
 )
 
 $ErrorActionPreference = "Stop"
@@ -130,6 +131,9 @@ Ensure-RustupTarget "aarch64-linux-android"
 Ensure-RustupTarget "armv7-linux-androideabi"
 Ensure-RustupTarget "i686-linux-android"
 Ensure-RustupTarget "x86_64-linux-android"
+Info "安装 Android 4.4 兼容 Rust 工具链 1.77.2..."
+rustup toolchain install 1.77.2 --profile minimal --target armv7-linux-androideabi
+Success "Android 4.4 兼容 Rust 工具链已就绪"
 
 # ============================================================
 Step 6 "安装 Rust cargo 工具"
@@ -174,7 +178,7 @@ if (-not $androidHome -or -not (Test-Path $androidHome)) {
     $env:ANDROID_SDK_ROOT = $androidHome
 
     # ============================================================
-    Step 9 "安装 Android NDK $NdkVersion（通过 sdkmanager）"
+    Step 9 "安装标准与 Android 4.4 兼容 NDK（通过 sdkmanager）"
 
     $sdkmanager = Get-Command sdkmanager -ErrorAction SilentlyContinue
     if (-not $sdkmanager) {
@@ -182,26 +186,26 @@ if (-not $androidHome -or -not (Test-Path $androidHome)) {
     }
 
     if ($sdkmanager) {
-        $ndkPath = Join-Path $androidHome "ndk\$NdkVersion"
-        if (Test-Path $ndkPath) {
-            Success "Android NDK $NdkVersion 已安装：$ndkPath"
-            [System.Environment]::SetEnvironmentVariable("ANDROID_NDK_ROOT", $ndkPath, "User")
-            $env:ANDROID_NDK_ROOT = $ndkPath
-        } else {
-            Info "安装 Android NDK $NdkVersion（需要网络，文件较大，请稍候）..."
-            # sdkmanager 需要接受许可证
-            "y" | & $sdkmanager.Source "ndk;$NdkVersion"
+        foreach ($version in @($NdkVersion, $CompatNdkVersion)) {
+            $ndkPath = Join-Path $androidHome "ndk\$version"
             if (Test-Path $ndkPath) {
-                Success "Android NDK $NdkVersion 安装完成：$ndkPath"
-                [System.Environment]::SetEnvironmentVariable("ANDROID_NDK_ROOT", $ndkPath, "User")
-                $env:ANDROID_NDK_ROOT = $ndkPath
+                Success "Android NDK $version 已安装：$ndkPath"
             } else {
-                Warn "NDK 安装后路径未找到，请手动确认：$ndkPath"
+                Info "安装 Android NDK $version（需要网络，文件较大，请稍候）..."
+                "y" | & $sdkmanager.Source "ndk;$version"
+                if (Test-Path $ndkPath) {
+                    Success "Android NDK $version 安装完成：$ndkPath"
+                } else {
+                    Warn "NDK 安装后路径未找到，请手动确认：$ndkPath"
+                }
             }
         }
+        $standardNdkPath = Join-Path $androidHome "ndk\$NdkVersion"
+        [System.Environment]::SetEnvironmentVariable("ANDROID_NDK_ROOT", $standardNdkPath, "User")
+        $env:ANDROID_NDK_ROOT = $standardNdkPath
     } else {
-        Warn "未找到 sdkmanager，请手动安装 NDK $NdkVersion"
-        Warn "  sdkmanager `"ndk;$NdkVersion`""
+        Warn "未找到 sdkmanager，请手动安装 NDK $NdkVersion 与 $CompatNdkVersion"
+        Warn "  sdkmanager `"ndk;$NdkVersion`" `"ndk;$CompatNdkVersion`""
     }
 }
 

--- a/scripts/tests/test_android_api19_build_contract.py
+++ b/scripts/tests/test_android_api19_build_contract.py
@@ -1,0 +1,30 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class AndroidApi19BuildContractTests(unittest.TestCase):
+    def test_ci_and_release_install_both_ndk_versions(self) -> None:
+        for relative_path in (".github/workflows/ci.yml", ".github/workflows/release.yml"):
+            content = (ROOT / relative_path).read_text(encoding="utf-8")
+            self.assertIn("ANDROID_NDK_VERSION: 29.0.14206865", content)
+            self.assertIn("ANDROID_NDK_API19_VERSION: 25.2.9519653", content)
+            self.assertIn('"ndk;${ANDROID_NDK_API19_VERSION}"', content)
+
+        release = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+        self.assertIn('"ndk;$env:ANDROID_NDK_API19_VERSION"', release)
+
+    def test_build_script_only_validates_dependencies(self) -> None:
+        content = (ROOT / "scripts/build-android-api19-resources.sh").read_text(
+            encoding="utf-8"
+        )
+        commands = [line.strip() for line in content.splitlines()]
+        self.assertNotIn('sdkmanager "ndk;25.2.9519653"', commands)
+        self.assertFalse(any(line.startswith("rustup toolchain install") for line in commands))
+        self.assertIn("未安装 Android 4.4 兼容构建所需的 NDK", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

Windows 发布任务只安装了标准 NDK r29。兼容资源脚本在 Git Bash 中尝试调用不可见的 `sdkmanager` 安装 r25c，导致 RC3 Windows 构建失败。

## 修复

- CI 与发布工作流显式安装 NDK r29 和 r25c；
- 三平台显式准备 Rust 1.77.2 API 19 工具链；
- 兼容资源脚本只验证依赖并构建，不再自行安装工具链；
- Windows 一键环境脚本同步安装两套 NDK 和兼容 Rust 工具链；
- 增加构建职责契约测试并更新环境文档。

## 验证

- `python3 -m unittest discover -s scripts/tests -v`：15 项通过；
- Shell 语法检查通过；
- 本机 `resources-api19.zip` 重新构建和 ELF 审计通过；
- 差异格式检查通过。
