### PR TITLE
fix: 修复 Android 9 共享库类加载冲突

### DIFF
--- a/docs/design/internals.md
+++ b/docs/design/internals.md
@@ -544,6 +544,16 @@ API 21～23 没有 `addDexPath(String, File)`，由 `DexInjector` 直接调用�
 
 ---
 
+### Bug 11：Android 9 动态 DEX 覆盖系统共享库类 ✅ 已修复
+
+- **现象**：原 APK 声明 `org.apache.http.legacy` 且自身包含同名编译桩时可以正常运行，加固后在 Android 9 启动并调用 Apache HTTP 类会抛出 `RuntimeException: Stub!`；Android 16 不受影响。
+- **根因**：Android 9 依赖安装期特殊类加载上下文提供共享库优先级，动态注入的解密 DEX 不会自动继承相同解析语义，业务 DEX 中的同名类可能覆盖系统共享库实现。
+- **修复**：API 28 在注入业务 DEX 前，根据 `ApplicationInfo.sharedLibraryFiles` 确认应用声明 `org.apache.http.legacy`，扫描已解密但尚未注入的业务 DEX，并通过应用原类加载器预解析其中 `org.apache.http.*` 与 `android.net.http.*` 类；此时业务 DEX 尚不可见，只能命中系统共享库。随后保持原有业务 DEX 前插顺序，其他系统版本不改变现有路径。
+- **验证要求**：Issue #17 样本在 API 28 调用 Apache HTTP 不再加载编译桩，同时回归 API 23、API 36、ARouter 和业务类优先级。
+- **验证记录**：Issue #17 样本在官方 API 28 模拟器成功预解析 376 个共享库类，启动后未再出现 `RuntimeException: Stub!`；同一加固 APK 已在 API 23 模拟器和 API 36 真机正常启动。
+
+---
+
 ### 代码健壮性修复 ✅ 已修复
 
 - `payload.len() as u32` 改为 `u32::try_from()`，超 4GiB 时报错而非截断

--- a/docs/process/test-checklist.md
+++ b/docs/process/test-checklist.md
@@ -98,6 +98,7 @@ bash tests/scripts/run-protect-e2e.sh
 - API 19 实验 Native 库必须由 r25c、Rust 1.77.2、`--platform 19` 构建，并通过 `scripts/verify-android-api19-native.sh` 的架构、依赖、动态符号与 ELF 审计
 - API 19 Native 依赖升级后必须执行 `tests/scripts/run-api19-native-probe.sh`，确认生产库能够进入 `JNI_OnLoad`，不能只以链接成功作为兼容结论
 - 工控兼容候选产物必须使用同一个 APK 在 API 19 和 API 23 设备验证，不能分别生成两份业务 APK 代替跨版本回归
+- API 28 对声明 `uses-library` 且业务 DEX 含同名编译桩的 APK，必须确认系统共享库类优先解析；Issue #17 Apache HTTP 样本不得出现 `RuntimeException: Stub!`
 
 ## APK 对齐与 Google Play 兼容
 

--- a/shield-stub/src/main/java/dev/mocika/shield/loader/DexInjector.java
+++ b/shield-stub/src/main/java/dev/mocika/shield/loader/DexInjector.java
@@ -23,6 +23,7 @@ final class DexInjector {
     private DexInjector() {}
 
     static void inject(Context context, List<File> dexFiles) throws Exception {
+        SharedLibraryCompat.prepare(context, dexFiles);
         ClassLoader classLoader = context.getClassLoader();
         File optimizedDirectory = Build.VERSION.SDK_INT < 26
                 ? context.getDir("dex_opt", Context.MODE_PRIVATE) : null;

--- a/shield-stub/src/main/java/dev/mocika/shield/loader/SharedLibraryCompat.java
+++ b/shield-stub/src/main/java/dev/mocika/shield/loader/SharedLibraryCompat.java
@@ -1,0 +1,70 @@
+package dev.mocika.shield.loader;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.os.Build;
+import android.util.Log;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.List;
+
+import dalvik.system.DexFile;
+
+/** 恢复 Android 9 动态 DEX 注入前的 Apache HTTP 共享库解析优先级。 */
+final class SharedLibraryCompat {
+
+    private static final String TAG = "dx";
+    private static final String LEGACY_HTTP_LIBRARY = "org.apache.http.legacy";
+    private static final String[] LEGACY_HTTP_PACKAGES = {
+            "org.apache.http.",
+            "android.net.http."
+    };
+
+    private SharedLibraryCompat() {}
+
+    static void prepare(Context context, List<File> dexFiles) throws IOException {
+        ApplicationInfo appInfo = context.getApplicationInfo();
+        if (!shouldPrepare(Build.VERSION.SDK_INT, appInfo.sharedLibraryFiles)) return;
+
+        ClassLoader appClassLoader = context.getClassLoader();
+        int loaded = 0;
+        int skipped = 0;
+        for (File dexPath : dexFiles) {
+            DexFile dexFile = new DexFile(dexPath);
+            try {
+                Enumeration<String> entries = dexFile.entries();
+                while (entries.hasMoreElements()) {
+                    String className = entries.nextElement();
+                    if (!isLegacyHttpClass(className)) continue;
+                    try {
+                        appClassLoader.loadClass(className);
+                        loaded++;
+                    } catch (ClassNotFoundException | LinkageError ignored) {
+                        skipped++;
+                    }
+                }
+            } finally {
+                dexFile.close();
+            }
+        }
+        Log.i(TAG, "legacy-http:prepared loaded=" + loaded + " skipped=" + skipped);
+    }
+
+    static boolean shouldPrepare(int sdkInt, String[] sharedLibraryFiles) {
+        if (sdkInt != 28 || sharedLibraryFiles == null) return false;
+        for (String path : sharedLibraryFiles) {
+            if (path != null && path.contains(LEGACY_HTTP_LIBRARY)) return true;
+        }
+        return false;
+    }
+
+    static boolean isLegacyHttpClass(String className) {
+        if (className == null) return false;
+        for (String prefix : LEGACY_HTTP_PACKAGES) {
+            if (className.startsWith(prefix)) return true;
+        }
+        return false;
+    }
+}

--- a/shield-stub/src/test/java/dev/mocika/shield/loader/SharedLibraryCompatTest.java
+++ b/shield-stub/src/test/java/dev/mocika/shield/loader/SharedLibraryCompatTest.java
@@ -1,0 +1,34 @@
+package dev.mocika.shield.loader;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SharedLibraryCompatTest {
+
+    @Test
+    public void 仅Android9且声明Apache共享库时启用() {
+        String[] libraries = new String[]{"/system/framework/org.apache.http.legacy.boot.jar"};
+
+        assertFalse(SharedLibraryCompat.shouldPrepare(27, libraries));
+        assertTrue(SharedLibraryCompat.shouldPrepare(28, libraries));
+        assertFalse(SharedLibraryCompat.shouldPrepare(29, libraries));
+    }
+
+    @Test
+    public void 没有共享库时跳过() {
+        assertFalse(SharedLibraryCompat.shouldPrepare(28, null));
+        assertFalse(SharedLibraryCompat.shouldPrepare(28, new String[0]));
+        assertFalse(SharedLibraryCompat.shouldPrepare(
+                28, new String[]{"/system/framework/其他库.jar"}));
+    }
+
+    @Test
+    public void 仅预解析Apache共享库包名() {
+        assertTrue(SharedLibraryCompat.isLegacyHttpClass(
+                "org.apache.http.message.AbstractHttpMessage"));
+        assertTrue(SharedLibraryCompat.isLegacyHttpClass("android.net.http.Headers"));
+        assertFalse(SharedLibraryCompat.isLegacyHttpClass("com.example.HttpClient"));
+    }
+}


### PR DESCRIPTION
## 问题

加固后的应用在 Android 9 动态注入业务 DEX 时，可能让业务包内的 Apache HTTP 编译桩覆盖系统 `org.apache.http.legacy` 共享库实现，最终抛出 `RuntimeException: Stub!`。

## 修复

- 仅在 Android 9 且应用声明 Apache HTTP 共享库时启用兼容处理
- 在业务 DEX 注入前，通过原应用类加载器预解析 Apache HTTP 相关类
- 保持现有 DEX 前插顺序，不改变 ARouter 和业务类优先级
- 补充单元测试、技术内参与回归清单

## 验证

- Issue #17 样本：官方 API 28 模拟器正常启动，预解析 376 个共享库类，未再出现 `RuntimeException: Stub!`
- 同一加固 APK：API 23 模拟器、API 36 真机正常启动
- `./gradlew testDebugUnitTest`
- `make build-stub`
- `make test`
- `python3 -m unittest discover -s scripts/tests -v`
- `cargo fmt --all --check`
- `bash tests/scripts/run-protect-e2e.sh`