### PR TITLE
fix: 修复Native库压缩导致安装失败

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,9 @@ Windows 下 `current_exe()`、`ProjectDirs`、Tauri `resource_dir()` 等接口�
 ### Windows 子进程无控制台窗口
 调用 `java`、`keytool`、`apksigner` 等子进程时，必须通过 `no_window_command(prog)` 辅助函数创建 `Command`，该函数在 `#[cfg(target_os = "windows")]` 下设置 `CREATE_NO_WINDOW` flag（其他平台零开销）。
 
+### Native 库打包
+原 APK 显式设置 `android:extractNativeLibs="false"` 时，加固输出必须保留该值，并确保全部 `lib/**/*.so` 使用 ZIP `Stored` 不压缩存储且按 16 KB 对齐。不得通过无条件改成 `true` 规避安装失败；签名链路继续保留原压缩策略。
+
 ### shield-gui 后端结构
 `apps/shield-gui/src-tauri` 是 Tauri binary crate，`main.rs` 只做启动、状态注入和 command 注册。后端逻辑按职责拆到 `app_config.rs`、`cert_service.rs`、`signing.rs`、`protect_runner.rs`、`updates.rs` 等模块；不要再把业务逻辑堆回 `main.rs`。
 

--- a/crates/shield-core/src/protect/manifest.rs
+++ b/crates/shield-core/src/protect/manifest.rs
@@ -2,6 +2,36 @@ use anyhow::{Context, Result};
 use std::fs;
 use std::path::Path;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NativeLibPackagingPolicy {
+    Disabled,
+    Enabled,
+    Unspecified,
+}
+
+pub(crate) fn read_native_lib_packaging_policy(apk_dir: &Path) -> Result<NativeLibPackagingPolicy> {
+    let manifest_path = apk_dir.join("AndroidManifest.xml");
+    let content = fs::read_to_string(&manifest_path).context("读取 AndroidManifest.xml 失败")?;
+    let app_tag_start = content
+        .find("<application")
+        .context("AndroidManifest.xml 中未找到 <application> 标签")?;
+    let app_tag_end = find_tag_end(&content, app_tag_start)
+        .context("AndroidManifest.xml <application> 标签未正常关闭")?;
+    let app_tag = &content[app_tag_start..app_tag_end];
+
+    Ok(
+        match extract_xml_attr(app_tag, "android:extractNativeLibs").as_deref() {
+            Some("false") => NativeLibPackagingPolicy::Disabled,
+            Some("true") => NativeLibPackagingPolicy::Enabled,
+            Some(value) => {
+                log::warn!("无法解析 extractNativeLibs 值 {value}，将保留原打包策略");
+                NativeLibPackagingPolicy::Unspecified
+            }
+            None => NativeLibPackagingPolicy::Unspecified,
+        },
+    )
+}
+
 pub(crate) fn modify_manifest(apk_dir: &Path, stub_app: &str) -> Result<()> {
     let manifest_path = apk_dir.join("AndroidManifest.xml");
     let content = fs::read_to_string(&manifest_path).context("读取 AndroidManifest.xml 失败")?;
@@ -208,6 +238,40 @@ mod tests {
         let tag = r#"<application android:name="App">"#;
         let result = remove_xml_attr(tag, "android:nonExistent");
         assert_eq!(result, tag);
+    }
+
+    #[test]
+    fn read_native_lib_packaging_policy_distinguishes_three_states() {
+        for (value, expected) in [
+            (Some("false"), NativeLibPackagingPolicy::Disabled),
+            (Some("true"), NativeLibPackagingPolicy::Enabled),
+            (None, NativeLibPackagingPolicy::Unspecified),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let attribute = value
+                .map(|it| format!(r#" android:extractNativeLibs="{it}""#))
+                .unwrap_or_default();
+            let manifest =
+                format!(r#"<manifest><application{attribute} android:name="App" /></manifest>"#);
+            fs::write(dir.path().join("AndroidManifest.xml"), manifest).unwrap();
+
+            assert_eq!(
+                read_native_lib_packaging_policy(dir.path()).unwrap(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn modify_manifest_preserves_extract_native_libs() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = r#"<manifest><application android:name="App" android:extractNativeLibs="false" /></manifest>"#;
+        fs::write(dir.path().join("AndroidManifest.xml"), manifest).unwrap();
+
+        modify_manifest(dir.path(), "dev.mocika.StubApp").unwrap();
+
+        let result = fs::read_to_string(dir.path().join("AndroidManifest.xml")).unwrap();
+        assert!(result.contains(r#"android:extractNativeLibs="false""#));
     }
 
     #[test]

--- a/crates/shield-core/src/protect_api.rs
+++ b/crates/shield-core/src/protect_api.rs
@@ -13,7 +13,7 @@ use crate::apk_inspect::{
 use crate::error::ShieldError;
 use crate::protect::{
     dex::process_dex,
-    manifest::modify_manifest,
+    manifest::{modify_manifest, read_native_lib_packaging_policy, NativeLibPackagingPolicy},
     runtime::{inject_runtime, read_stub_application},
 };
 use crate::utils::is_json_mode;
@@ -21,7 +21,7 @@ use crate::utils::{
     create_temp_dir, find_apksigner, find_apktool, find_java, find_runtime_resources, human_size,
     print_step, print_success, run_command,
 };
-use crate::zipalign::align_apk;
+use crate::zipalign::{align_apk_with_native_packaging, NativeLibraryPackaging};
 
 #[derive(Debug, Clone)]
 pub struct ProtectOptions {
@@ -143,6 +143,8 @@ pub fn protect_apk(
     print_success("解包完成");
 
     let stub_app = read_stub_application(&runtime_resources).map_err(ShieldError::from)?;
+    let native_lib_policy =
+        read_native_lib_packaging_policy(&apk_dir).map_err(ShieldError::from)?;
 
     emit_progress(
         &on_progress,
@@ -212,10 +214,20 @@ pub fn protect_apk(
 
     emit_progress(&on_progress, &cancel, ProgressStep::AlignApk, "对齐APK数据")?;
     print_step("对齐APK数据");
-    align_apk(&opts.output).map_err(ShieldError::from)?;
+    align_apk_with_native_packaging(&opts.output, native_library_packaging(native_lib_policy))
+        .map_err(ShieldError::from)?;
     print_success("APK数据对齐完成");
 
     Ok(())
+}
+
+fn native_library_packaging(policy: NativeLibPackagingPolicy) -> NativeLibraryPackaging {
+    match policy {
+        NativeLibPackagingPolicy::Disabled => NativeLibraryPackaging::Store,
+        NativeLibPackagingPolicy::Enabled | NativeLibPackagingPolicy::Unspecified => {
+            NativeLibraryPackaging::Preserve
+        }
+    }
 }
 
 fn validate_apk_eligibility(outcome: &ApkCheckOutcome) -> anyhow::Result<()> {
@@ -270,8 +282,26 @@ fn check_cancel(cancel: &Arc<AtomicBool>) -> std::result::Result<(), ShieldError
 
 #[cfg(test)]
 mod tests {
-    use super::{validate_apk_eligibility, validate_output_certificate};
+    use super::{native_library_packaging, validate_apk_eligibility, validate_output_certificate};
     use crate::apk_inspect::ApkCheckOutcome;
+    use crate::protect::manifest::NativeLibPackagingPolicy;
+    use crate::zipalign::NativeLibraryPackaging;
+
+    #[test]
+    fn extract_native_libs_false_映射为不压缩策略() {
+        assert_eq!(
+            native_library_packaging(NativeLibPackagingPolicy::Disabled),
+            NativeLibraryPackaging::Store
+        );
+        assert_eq!(
+            native_library_packaging(NativeLibPackagingPolicy::Enabled),
+            NativeLibraryPackaging::Preserve
+        );
+        assert_eq!(
+            native_library_packaging(NativeLibPackagingPolicy::Unspecified),
+            NativeLibraryPackaging::Preserve
+        );
+    }
 
     #[test]
     fn 已加固_apk_被核心入口拒绝() {

--- a/crates/shield-core/src/zipalign.rs
+++ b/crates/shield-core/src/zipalign.rs
@@ -4,7 +4,7 @@ use std::io::{self, Read, Write};
 use std::path::Path;
 use tempfile::NamedTempFile;
 use zip::write::SimpleFileOptions;
-use zip::{DateTime, ZipArchive, ZipWriter};
+use zip::{CompressionMethod, DateTime, ZipArchive, ZipWriter};
 
 const DEFAULT_ALIGNMENT: u16 = 4;
 const SHARED_LIB_ALIGNMENT: u16 = 16 * 1024;
@@ -16,8 +16,18 @@ pub struct AlignmentIssue {
     pub actual: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NativeLibraryPackaging {
+    Preserve,
+    Store,
+}
+
+fn is_native_library(name: &str) -> bool {
+    name.starts_with("lib/") && name.ends_with(".so")
+}
+
 fn required_alignment(name: &str) -> u16 {
-    if name.starts_with("lib/") && name.ends_with(".so") {
+    if is_native_library(name) {
         SHARED_LIB_ALIGNMENT
     } else {
         DEFAULT_ALIGNMENT
@@ -28,9 +38,19 @@ fn is_directory_name(name: &str) -> bool {
     name.ends_with('/')
 }
 
-fn build_file_options(file: &zip::read::ZipFile<'_>, alignment: u16) -> SimpleFileOptions {
+fn build_file_options(
+    file: &zip::read::ZipFile<'_>,
+    alignment: u16,
+    native_packaging: NativeLibraryPackaging,
+) -> SimpleFileOptions {
+    let compression =
+        if native_packaging == NativeLibraryPackaging::Store && is_native_library(file.name()) {
+            CompressionMethod::Stored
+        } else {
+            file.compression()
+        };
     let mut options = SimpleFileOptions::default()
-        .compression_method(file.compression())
+        .compression_method(compression)
         .last_modified_time(
             file.last_modified()
                 .filter(DateTime::is_valid)
@@ -79,13 +99,20 @@ pub fn verify_apk_alignment(path: &Path) -> Result<Vec<AlignmentIssue>> {
 }
 
 pub fn align_apk(path: &Path) -> Result<()> {
+    align_apk_with_native_packaging(path, NativeLibraryPackaging::Preserve)
+}
+
+pub(crate) fn align_apk_with_native_packaging(
+    path: &Path,
+    native_packaging: NativeLibraryPackaging,
+) -> Result<()> {
     let parent = path
         .parent()
         .with_context(|| format!("无法确定 APK 父目录: {}", path.display()))?;
     let mut temp = NamedTempFile::new_in(parent)
         .with_context(|| format!("创建临时对齐文件失败: {}", parent.display()))?;
 
-    rewrite_aligned(path, temp.as_file_mut())?;
+    rewrite_aligned(path, temp.as_file_mut(), native_packaging)?;
     temp.as_file_mut()
         .flush()
         .context("刷新对齐后的 APK 失败")?;
@@ -110,7 +137,40 @@ pub fn align_apk(path: &Path) -> Result<()> {
         );
     }
 
+    if native_packaging == NativeLibraryPackaging::Store {
+        let compressed = find_compressed_native_libraries(path)?;
+        if !compressed.is_empty() {
+            anyhow::bail!(
+                "Native 库打包与 extractNativeLibs=false 不一致，仍存在压缩条目：{}",
+                compressed
+                    .into_iter()
+                    .take(5)
+                    .collect::<Vec<_>>()
+                    .join("；")
+            );
+        }
+    }
+
     Ok(())
+}
+
+pub(crate) fn find_compressed_native_libraries(path: &Path) -> Result<Vec<String>> {
+    let file =
+        fs::File::open(path).with_context(|| format!("打开 APK 失败: {}", path.display()))?;
+    let mut archive = ZipArchive::new(file)
+        .with_context(|| format!("解析 APK ZIP 结构失败: {}", path.display()))?;
+    let mut compressed = Vec::new();
+
+    for index in 0..archive.len() {
+        let entry = archive
+            .by_index(index)
+            .with_context(|| format!("读取 ZIP 条目失败: index={index}"))?;
+        if is_native_library(entry.name()) && entry.compression() != CompressionMethod::Stored {
+            compressed.push(entry.name().to_string());
+        }
+    }
+
+    Ok(compressed)
 }
 
 fn format_alignment_issues(issues: &[AlignmentIssue]) -> String {
@@ -132,7 +192,11 @@ fn format_alignment_issues(issues: &[AlignmentIssue]) -> String {
     parts.join("；")
 }
 
-fn rewrite_aligned(path: &Path, output: &mut fs::File) -> Result<()> {
+fn rewrite_aligned(
+    path: &Path,
+    output: &mut fs::File,
+    native_packaging: NativeLibraryPackaging,
+) -> Result<()> {
     let input =
         fs::File::open(path).with_context(|| format!("打开 APK 失败: {}", path.display()))?;
     let mut archive = ZipArchive::new(input)
@@ -152,7 +216,7 @@ fn rewrite_aligned(path: &Path, output: &mut fs::File) -> Result<()> {
             .with_context(|| format!("读取 ZIP 条目失败: index={i}"))?;
         let name = file.name().to_string();
         let alignment = required_alignment(&name);
-        let options = build_file_options(&file, alignment);
+        let options = build_file_options(&file, alignment, native_packaging);
 
         if file.is_dir() || is_directory_name(&name) {
             writer
@@ -183,7 +247,6 @@ mod tests {
     use std::path::PathBuf;
     use std::process::Command;
     use tempfile::tempdir;
-    use zip::CompressionMethod;
 
     fn make_sample_apk(path: &Path) {
         let file = fs::File::create(path).unwrap();
@@ -313,6 +376,47 @@ mod tests {
 
         let payload_offset = archive.by_name("res/raw/payload.bin").unwrap().data_start();
         assert_eq!(payload_offset % DEFAULT_ALIGNMENT as u64, 0);
+    }
+
+    #[test]
+    fn store_native_libraries_rewrites_only_so_as_stored() {
+        let dir = tempdir().unwrap();
+        let apk = dir.path().join("sample.apk");
+        make_sample_apk(&apk);
+
+        align_apk_with_native_packaging(&apk, NativeLibraryPackaging::Store).unwrap();
+
+        assert!(find_compressed_native_libraries(&apk).unwrap().is_empty());
+        let file = fs::File::open(&apk).unwrap();
+        let mut archive = ZipArchive::new(file).unwrap();
+        assert_eq!(
+            archive
+                .by_name("lib/arm64-v8a/libdemo.so")
+                .unwrap()
+                .compression(),
+            CompressionMethod::Stored
+        );
+        assert_eq!(
+            archive
+                .by_name("AndroidManifest.xml")
+                .unwrap()
+                .compression(),
+            CompressionMethod::Deflated
+        );
+    }
+
+    #[test]
+    fn preserve_native_libraries_keeps_compression_method() {
+        let dir = tempdir().unwrap();
+        let apk = dir.path().join("sample.apk");
+        make_sample_apk(&apk);
+
+        align_apk(&apk).unwrap();
+
+        assert_eq!(
+            find_compressed_native_libraries(&apk).unwrap(),
+            vec!["lib/arm64-v8a/libdemo.so"]
+        );
     }
 
     #[test]

--- a/docs/design/native-library-packaging.md
+++ b/docs/design/native-library-packaging.md
@@ -2,6 +2,8 @@
 
 本文定义 Mocika Shield 加固过程中对 `android:extractNativeLibs`、APK 内 `.so` 压缩方式、ZIP 对齐和 ELF 页大小兼容性的处理规则。该设计用于修复原 APK 显式设置 `extractNativeLibs=false` 且原本不包含 Native 库时，加固产物无法安装的问题。
 
+当前状态：核心修复与自动结构回归已经实现，Android 16/API 36 已完成有/无原始 Native 库两类真机安装验证；API 23 和 API 35 16 KB 设备矩阵仍在候选版本阶段执行。
+
 ## 问题与复现证据
 
 已使用项目 Smoke APK 在 Android 16/API 36 真机复现：
@@ -81,7 +83,7 @@ apktool 解包
 
 ## ZIP 重写规则
 
-现有 `align_apk()` 默认保留每个 ZIP 条目的压缩方式。后续实现应增加内部策略参数，不改变签名等其他调用方的默认行为：
+现有 `align_apk()` 默认保留每个 ZIP 条目的压缩方式。加固流程通过内部策略参数选择 Native 库处理方式，不改变签名等其他调用方的默认行为：
 
 ```text
 Preserve
@@ -126,20 +128,20 @@ StoreNativeLibraries
 
 ## 实施阶段
 
-### 打包策略与核心修复
+### 打包策略与核心修复（已完成）
 
 - 增加 Manifest 三态解析及单元测试。
 - 为 ZIP 重写增加内部 Native 库存储策略。
 - 在加固流程中传递策略，原 APK 显式为 `false` 时强制全部 `.so` 不压缩。
 - 保持 `true` 和未设置样本的原有压缩策略，记录加固前后体积变化。
 
-### 产物验证与诊断
+### 产物验证与诊断（进行中）
 
 - 扩展对齐验证结果，区分压缩方式和数据偏移错误。
 - 将 Stub ELF 审计与发布资源检查关联，但不在每次普通文档 CI 中执行重型构建。
 - 补充 `INSTALL_FAILED_INVALID_APK` 与 `Failed to extract native libraries` 的排障提示。
 
-### 自动与设备回归
+### 自动与设备回归（进行中）
 
 - 扩展 Smoke 夹具，至少生成显式 `false` 的有 Native 库和无 Native 库两种输入。
 - 断言加固后 Manifest 仍为 `false`，全部 `.so` 为 `Stored` 且 16 KB 对齐。

--- a/docs/process/roadmap.md
+++ b/docs/process/roadmap.md
@@ -43,12 +43,14 @@
 | 项 | 内容 |
 |----|------|
 | **优先级** | 高 |
-| **状态** | 待修复 |
+| **状态** | 进行中 |
 | **涉及文件** | `crates/shield-core` Manifest 解析、ZIP 重写与端到端测试 |
 
 **复现结果**：原 APK 显式设置 `android:extractNativeLibs="false"` 且本身不含 Native 库时，加固新增的四架构 `libmocikashield.so` 会被 apktool 重打包为压缩条目。产物虽通过现有 16 KB ZIP 偏移校验，仍在 Android 16 真机安装时报 `INSTALL_FAILED_INVALID_APK: Failed to extract native libraries`。
 
 **修复方向**：保留原 Manifest 三态语义；仅在显式 `false` 时强制全部 `lib/**/*.so` 使用不压缩存储并按 16 KB 对齐，同时独立验证 Stub ELF `LOAD` 段。不得以无条件改成 `extractNativeLibs=true` 作为正式修复。
+
+**当前进展**：核心已实现 Manifest 三态解析、按策略重写 Native 库和压缩条目复验；自动端到端测试覆盖原 APK 无 Native 库且显式为 `false` 的场景。Android 16 真机已确认该场景由安装失败修复为安装成功；已有 Native 库的 ARouter 样本已通过覆盖安装、冷启动和 Native 直接加载。候选版本前仍需完成 API 23 与 API 35 16 KB 验证。
 
 **完成条件**：有/无原生 Native 库的显式 `false` 样本均保持 Manifest 不变，所有 `.so` 为不压缩且 16 KB 对齐；完成自动结构测试、Android 16 真机安装启动，以及候选版本设备矩阵回归。详细设计见 [Android Native 库打包与加载兼容设计](../design/native-library-packaging.md)。
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,7 +2,7 @@
 
 `fixtures/android-smoke-app` 是项目自有的最小 Android 测试夹具，只负责提供包含自定义 `Application` 和启动 `Activity` 的稳定输入 APK，不承载产品示例或业务功能。
 
-`scripts/run-protect-e2e.sh` 负责无设备回归链路：编译测试 APK、临时生成测试证书、签名原始 APK、执行加固、再次签名，并验证签名、MSHD 块、壳 Native 库和 `check-apk` 结果。
+`scripts/run-protect-e2e.sh` 负责无设备回归链路：编译显式设置 `extractNativeLibs=false` 且原本不含 Native 库的测试 APK，临时生成测试证书、签名原始 APK、执行加固、再次签名，并验证签名、MSHD 块、壳 Native 库、Manifest 保留和全部 `.so` 不压缩存储，以及 `check-apk` 结果。
 
 ```bash
 make build-stub

--- a/tests/fixtures/android-smoke-app/app/src/main/AndroidManifest.xml
+++ b/tests/fixtures/android-smoke-app/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     <application
         android:name=".SmokeApplication"
         android:allowBackup="false"
+        android:extractNativeLibs="false"
         android:label="@string/app_name">
         <activity
             android:name=".MainActivity"

--- a/tests/scripts/run-protect-e2e.sh
+++ b/tests/scripts/run-protect-e2e.sh
@@ -49,4 +49,15 @@ unzip -p "$FINAL" classes.dex > "$WORK/classes.dex"
 grep -a -q 'MSHD' "$WORK/classes.dex"
 unzip -l "$FINAL" | grep -q 'lib/arm64-v8a/libmocikashield.so'
 
+DECODED="$WORK/output-decoded"
+java -jar "$ROOT/tools/apktool_3.0.1.jar" d "$FINAL" -o "$DECODED" -f --no-src >/dev/null
+grep -q 'android:extractNativeLibs="false"' "$DECODED/AndroidManifest.xml"
+
+COMPRESSED_SO="$(unzip -lv "$FINAL" | awk '$NF ~ /^lib\/.+\.so$/ && $2 != "Stored" { print $NF }')"
+if [ -n "$COMPRESSED_SO" ]; then
+  echo "extractNativeLibs=false 时存在压缩 Native 库：" >&2
+  printf '%s\n' "$COMPRESSED_SO" >&2
+  exit 1
+fi
+
 echo "端到端加固回归测试通过"


### PR DESCRIPTION
## 问题

原 APK 显式设置 `android:extractNativeLibs=false` 且原本没有 Native 库时，apktool 会把新注入的 `libmocikashield.so` 打包为压缩条目。即使 ZIP 偏移已经 16 KB 对齐，Android 安装仍会失败并返回 `Failed to extract native libraries`。

## 修复

- 解析并保留 `extractNativeLibs` 的 false、true、未设置三态
- 仅在显式 false 时将全部 `lib/**/*.so` 重写为 ZIP Stored
- 保持 `.so` 16 KB 对齐，并在输出后复验压缩方式
- true、未设置及独立签名链路继续保留原压缩策略
- 扩展端到端测试，覆盖原 APK 无 Native 库的显式 false 场景
- 同步设计文档、路线图、测试说明和项目约束

## 验证

- `cargo test -p shield-core`：79 项通过
- `cargo test -p shield-cli`：通过
- `cargo clippy -p shield-core --all-targets -- -D warnings`：通过
- `bash tests/scripts/run-protect-e2e.sh`：通过
- Android 16 无原始 Native 库样本：由安装失败修复为安装成功
- Android 16 已有 Native 库 ARouter 样本：覆盖安装、冷启动、Native 直接加载成功
- 官方 `zipalign -c -P 16 -v 4`：通过

## 后续

API 23 与 API 35 16 KB 设备矩阵在候选版本阶段继续验证；本 PR 不发布版本。