### PR TITLE
test: 修复 Smoke 多 DEX 端到端夹具

### DIFF
--- a/docs/process/test-checklist.md
+++ b/docs/process/test-checklist.md
@@ -13,6 +13,12 @@ bash tests/scripts/run-protect-e2e.sh
 
 脚本使用项目自有最小 Android 测试夹具，验证从源码 APK 到已签名加固产物的完整无设备链路。手动触发完整 CI 时，“Android 壳构建”任务也会执行该测试。
 
+连接测试设备后执行以下命令，分别启动未加固双 DEX 基线，并以同一签名覆盖安装加固包。两次启动都必须观察到 `Application`、`Activity` 和 `classes2.dex` 中 `SecondaryMarker` 的成功标记：
+
+```bash
+RUN_DEVICE_TEST=1 bash tests/scripts/run-protect-e2e.sh
+```
+
 ## 使用时机
 
 - 发布 `rc` 或稳定版本前

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,14 +2,20 @@
 
 `fixtures/android-smoke-app` 是项目自有的最小 Android 测试夹具，只负责提供包含自定义 `Application` 和启动 `Activity` 的稳定输入 APK，不承载产品示例或业务功能。
 
-`scripts/run-protect-e2e.sh` 负责无设备回归链路：编译显式设置 `extractNativeLibs=false` 且原本不含 Native 库的测试 APK，临时生成测试证书、签名原始 APK、执行加固、再次签名，并验证签名、MSHD 块、壳 Native 库、Manifest 保留和全部 `.so` 不压缩存储，以及 `check-apk` 结果。
+`scripts/build-smoke-multidex.sh` 会把独立编译的 `SecondaryMarker` 写入 `classes2.dex`。`scripts/run-protect-e2e.sh` 以这个真实双 DEX APK 为输入，负责无设备回归链路：编译显式设置 `extractNativeLibs=false` 且原本不含 Native 库的测试 APK，临时生成测试证书、签名原始 APK、执行加固、再次签名，并验证签名、MSHD 块、壳 Native 库、Manifest 保留和全部 `.so` 不压缩存储，以及 `check-apk` 结果。
 
 ```bash
 make build-stub
 bash tests/scripts/run-protect-e2e.sh
 ```
 
-测试证书只在系统临时目录中生成，脚本退出时自动清理，不向仓库提交任何私钥。日常 CI 不启动模拟器；首次安装、清除数据、框架路由和真实运行时加载仍按发布测试清单在真机完成。
+连接 Android 设备后，可以额外验证未加固双 DEX 基线，以及使用同一证书覆盖安装加固包后的运行时加载：
+
+```bash
+RUN_DEVICE_TEST=1 bash tests/scripts/run-protect-e2e.sh
+```
+
+存在多个在线设备时通过 `ANDROID_SERIAL` 指定目标设备。测试证书只在系统临时目录中生成，脚本退出时自动清理，不向仓库提交任何私钥。日常 CI 不启动模拟器；真实运行时回归由维护者在真机或指定模拟器上按需执行。
 
 ## Android 4.4 Native 加载探针
 

--- a/tests/scripts/build-smoke-multidex.sh
+++ b/tests/scripts/build-smoke-multidex.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# 为 Smoke 测试 APK 注入独立的 classes2.dex，确保端到端回归真实覆盖多 DEX 加载。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURE="$PROJECT_ROOT/tests/fixtures/android-smoke-app"
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+    echo "用法：$0 <输入未签名 APK> <输出未签名 APK> [最低 API]" >&2
+    exit 1
+fi
+
+INPUT_APK="$1"
+OUTPUT_APK="$2"
+MIN_API="${3:-19}"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mocika-smoke-multidex.XXXXXX")"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+for command in javac unzip zip; do
+    command -v "$command" >/dev/null || { echo "缺少命令：$command" >&2; exit 1; }
+done
+
+if [[ -z "${ANDROID_HOME:-}" ]]; then
+    echo "缺少 ANDROID_HOME 环境变量" >&2
+    exit 1
+fi
+
+if [[ ! -f "$INPUT_APK" ]]; then
+    echo "输入 APK 不存在：$INPUT_APK" >&2
+    exit 1
+fi
+
+BUILD_TOOLS_VERSION="$(find "$ANDROID_HOME/build-tools" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort -V | tail -n 1)"
+PLATFORM_VERSION="$(find "$ANDROID_HOME/platforms" -mindepth 1 -maxdepth 1 -type d -name 'android-*' -exec basename {} \; | sort -t- -k2,2n | tail -n 1)"
+D8="$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION/d8"
+ANDROID_JAR="$ANDROID_HOME/platforms/$PLATFORM_VERSION/android.jar"
+
+if [[ ! -x "$D8" || ! -f "$ANDROID_JAR" ]]; then
+    echo "Android SDK 缺少可用的 d8 或 android.jar" >&2
+    exit 1
+fi
+
+SECONDARY_CLASSES="$WORK_DIR/secondary-classes"
+SECONDARY_DEX="$WORK_DIR/secondary-dex"
+mkdir -p "$SECONDARY_CLASSES" "$SECONDARY_DEX"
+
+javac -source 8 -target 8 -cp "$ANDROID_JAR" -d "$SECONDARY_CLASSES" \
+    "$FIXTURE/secondary-src/dev/mocika/shield/smoke/SecondaryMarker.java"
+"$D8" --min-api "$MIN_API" --lib "$ANDROID_JAR" --output "$SECONDARY_DEX" \
+    "$SECONDARY_CLASSES/dev/mocika/shield/smoke/SecondaryMarker.class"
+
+mkdir -p "$(dirname "$OUTPUT_APK")"
+cp "$INPUT_APK" "$OUTPUT_APK"
+cp "$SECONDARY_DEX/classes.dex" "$WORK_DIR/classes2.dex"
+zip -qj "$OUTPUT_APK" "$WORK_DIR/classes2.dex"
+
+if ! unzip -l "$OUTPUT_APK" | awk '$NF == "classes2.dex" { found = 1 } END { exit !found }'; then
+    echo "生成的 Smoke APK 缺少 classes2.dex" >&2
+    exit 1
+fi
+
+echo "Smoke 双 DEX APK 已生成：$OUTPUT_APK"

--- a/tests/scripts/run-api19-protect-e2e.sh
+++ b/tests/scripts/run-api19-protect-e2e.sh
@@ -38,20 +38,8 @@ PROTECTED="$WORK_DIR/output-protected.apk"
 FINAL="$WORK_DIR/output-protected-signed.apk"
 KEYSTORE="$WORK_DIR/smoke.p12"
 
-BUILD_TOOLS_VERSION="$(ls "$ANDROID_HOME/build-tools" | sort -t. -k1,1n -k2,2n -k3,3n | tail -n 1)"
-PLATFORM_VERSION="$(ls "$ANDROID_HOME/platforms" | sort -t- -k2,2n | tail -n 1)"
-D8="$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION/d8"
-ANDROID_JAR="$ANDROID_HOME/platforms/$PLATFORM_VERSION/android.jar"
-SECONDARY_CLASSES="$WORK_DIR/secondary-classes"
-SECONDARY_DEX="$WORK_DIR/secondary-dex"
-mkdir -p "$SECONDARY_CLASSES" "$SECONDARY_DEX"
-javac -source 8 -target 8 -cp "$ANDROID_JAR" -d "$SECONDARY_CLASSES" \
-    "$FIXTURE/secondary-src/dev/mocika/shield/smoke/SecondaryMarker.java"
-"$D8" --min-api 19 --lib "$ANDROID_JAR" --output "$SECONDARY_DEX" \
-    "$SECONDARY_CLASSES/dev/mocika/shield/smoke/SecondaryMarker.class"
-cp "$UNSIGNED" "$MULTIDEX_UNSIGNED"
-cp "$SECONDARY_DEX/classes.dex" "$WORK_DIR/classes2.dex"
-zip -qj "$MULTIDEX_UNSIGNED" "$WORK_DIR/classes2.dex"
+"$PROJECT_ROOT/tests/scripts/build-smoke-multidex.sh" \
+    "$UNSIGNED" "$MULTIDEX_UNSIGNED" 19
 
 keytool -genkeypair -noprompt -storetype PKCS12 \
     -keystore "$KEYSTORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \

--- a/tests/scripts/run-protect-e2e.sh
+++ b/tests/scripts/run-protect-e2e.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FIXTURE="$ROOT/tests/fixtures/android-smoke-app"
+PACKAGE_NAME="dev.mocika.shield.smoke"
+COMPONENT="$PACKAGE_NAME/.MainActivity"
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/mocika-protect-e2e.XXXXXX")"
 trap 'rm -rf "$WORK"' EXIT
 
@@ -18,12 +20,15 @@ test -f "$ROOT/shield-stub/build/outputs/resources/resources.zip" || {
 "$ROOT/shield-stub/gradlew" -p "$FIXTURE" :app:assembleRelease --no-daemon
 cargo build --release -p shield-cli --manifest-path "$ROOT/Cargo.toml"
 
-UNSIGNED="$FIXTURE/app/build/outputs/apk/release/app-release-unsigned.apk"
+BASE_UNSIGNED="$FIXTURE/app/build/outputs/apk/release/app-release-unsigned.apk"
+UNSIGNED="$WORK/input-multidex-unsigned.apk"
 SIGNED="$WORK/input-signed.apk"
 PROTECTED="$WORK/output-protected.apk"
 FINAL="$WORK/output-protected-signed.apk"
 KEYSTORE="$WORK/smoke.p12"
 PASSWORD="mocika-test-123"
+
+"$ROOT/tests/scripts/build-smoke-multidex.sh" "$BASE_UNSIGNED" "$UNSIGNED" 19
 
 keytool -genkeypair -noprompt -storetype PKCS12 \
   -keystore "$KEYSTORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
@@ -58,6 +63,42 @@ if [ -n "$COMPRESSED_SO" ]; then
   echo "extractNativeLibs=false 时存在压缩 Native 库：" >&2
   printf '%s\n' "$COMPRESSED_SO" >&2
   exit 1
+fi
+
+verify_launch() {
+  local scenario="$1"
+  adb "${ADB_ARGS[@]}" logcat -c
+  adb "${ADB_ARGS[@]}" shell am force-stop "$PACKAGE_NAME" >/dev/null 2>&1 || true
+  adb "${ADB_ARGS[@]}" shell am start -W -n "$COMPONENT" >/dev/null
+  for _ in $(seq 1 30); do
+    local logs
+    logs="$(adb "${ADB_ARGS[@]}" logcat -d -s MocikaSmoke:I AndroidRuntime:E '*:S')"
+    if grep -q 'MOCIKA_SMOKE_APPLICATION_OK' <<< "$logs" \
+      && grep -q 'MOCIKA_SMOKE_ACTIVITY_OK' <<< "$logs" \
+      && grep -q 'MOCIKA_SMOKE_SECONDARY_OK' <<< "$logs"; then
+      echo "$scenario 验证通过"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "错误：$scenario 未观察到完整启动标记" >&2
+  adb "${ADB_ARGS[@]}" logcat -d -s MocikaSmoke:V AndroidRuntime:E '*:S' >&2
+  return 1
+}
+
+if [[ "${RUN_DEVICE_TEST:-0}" == "1" ]]; then
+  command -v adb >/dev/null || { echo "缺少命令：adb" >&2; exit 1; }
+  ADB_ARGS=()
+  if [[ -n "${ANDROID_SERIAL:-}" ]]; then
+    ADB_ARGS=(-s "$ANDROID_SERIAL")
+  fi
+
+  adb "${ADB_ARGS[@]}" get-state >/dev/null
+  adb "${ADB_ARGS[@]}" uninstall "$PACKAGE_NAME" >/dev/null 2>&1 || true
+  adb "${ADB_ARGS[@]}" install "$SIGNED" | grep -q '^Success'
+  verify_launch "未加固双 DEX 基线"
+  adb "${ADB_ARGS[@]}" install -r "$FINAL" | grep -q '^Success'
+  verify_launch "同签名覆盖安装加固包"
 fi
 
 echo "端到端加固回归测试通过"


### PR DESCRIPTION
## 变更内容

- 抽取共享脚本，生成包含独立 `classes2.dex` 的真实 Smoke 测试 APK
- 常规与 Android 4.4 端到端脚本复用同一生成流程
- 增加可选真机模式，验证未加固基线及同签名覆盖安装后的加固包启动
- 补充测试说明与发布前回归清单

## 验证结果

- `bash -n tests/scripts/build-smoke-multidex.sh tests/scripts/run-protect-e2e.sh tests/scripts/run-api19-protect-e2e.sh`
- `bash tests/scripts/run-protect-e2e.sh`
- `RUN_DEVICE_TEST=1 ANDROID_SERIAL=3d6dfdec bash tests/scripts/run-protect-e2e.sh`
- Android 16 真机上未加固与加固双 DEX APK 均观察到 Application、Activity、SecondaryMarker 成功标记
- `git diff --check`