### PR TITLE
test: 修复 ZIP 条目断言误退出

### DIFF
--- a/scripts/build-android-api19-resources.sh
+++ b/scripts/build-android-api19-resources.sh
@@ -114,7 +114,8 @@ if ! unzip -tq "$LEGACY_RESOURCES" >/dev/null; then
     exit 1
 fi
 for required_entry in stub-classes.dex lib/armeabi-v7a/libmocikashield.so metadata.json; do
-    if ! unzip -Z1 "$LEGACY_RESOURCES" | grep -qx "$required_entry"; then
+    if ! unzip -Z1 "$LEGACY_RESOURCES" \
+        | awk -v required="$required_entry" '$0 == required { found = 1 } END { exit !found }'; then
         echo "错误：Android 4.4 兼容资源包缺少 $required_entry"
         exit 1
     fi

--- a/tests/scripts/run-protect-e2e.sh
+++ b/tests/scripts/run-protect-e2e.sh
@@ -52,7 +52,8 @@ printf '%s\n' "$CHECK_RESULT" | grep -q '"is_signed":true'
 
 unzip -p "$FINAL" classes.dex > "$WORK/classes.dex"
 grep -a -q 'MSHD' "$WORK/classes.dex"
-unzip -l "$FINAL" | grep -q 'lib/arm64-v8a/libmocikashield.so'
+unzip -l "$FINAL" \
+  | awk '$NF == "lib/arm64-v8a/libmocikashield.so" { found = 1 } END { exit !found }'
 
 DECODED="$WORK/output-decoded"
 java -jar "$ROOT/tools/apktool_3.0.1.jar" d "$FINAL" -o "$DECODED" -f --no-src >/dev/null


### PR DESCRIPTION
## 变更内容

- 避免 `pipefail` 下 `unzip | grep -q` 因提前关闭管道而偶发失败
- 常规端到端与 Android 4.4 资源检查统一消费完整 ZIP 条目列表后判定

## 验证结果

- `bash -n tests/scripts/run-protect-e2e.sh scripts/build-android-api19-resources.sh`
- Android API 23：未加固基线、加固首次解密、缓存命中二次启动均通过
- Android API 28：修复断言后上述三条路径均通过
- 两个模拟器验证后均已停止