### PR TITLE
chore: 发布1.2.7正式版本

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "mocika-shield"
-version = "1.2.7-rc.5"
+version = "1.2.7"
 dependencies = [
  "chacha20poly1305",
  "dunce",
@@ -2168,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "mocikashield"
-version = "1.2.7-rc.5"
+version = "1.2.7"
 dependencies = [
  "chacha20poly1305",
  "hkdf",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "shield-cli"
-version = "1.2.7-rc.5"
+version = "1.2.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "shield-core"
-version = "1.2.7-rc.5"
+version = "1.2.7"
 dependencies = [
  "anyhow",
  "chacha20poly1305",

--- a/apps/shield-cli/Cargo.toml
+++ b/apps/shield-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shield-cli"
-version = "1.2.7-rc.5"
+version = "1.2.7"
 edition = "2021"
 authors = ["MocikaDev"]
 license = "MIT"

--- a/apps/shield-gui/package-lock.json
+++ b/apps/shield-gui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mocika-shield-gui",
-  "version": "1.2.7-rc.5",
+  "version": "1.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mocika-shield-gui",
-      "version": "1.2.7-rc.5",
+      "version": "1.2.7",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.19",
         "@radix-ui/react-label": "^2.1.11",

--- a/apps/shield-gui/package.json
+++ b/apps/shield-gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocika-shield-gui",
-  "version": "1.2.7-rc.5",
+  "version": "1.2.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/shield-gui/src-tauri/Cargo.toml
+++ b/apps/shield-gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mocika-shield"
-version = "1.2.7-rc.5"
+version = "1.2.7"
 edition = "2021"
 publish = false
 description = "Mocika Shield APK 加固工具桌面 GUI"

--- a/apps/shield-gui/src-tauri/tauri.conf.json
+++ b/apps/shield-gui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MocikaShield",
-  "version": "1.2.7-rc.5",
+  "version": "1.2.7",
   "identifier": "dev.mocika.shield-gui",
   "build": {
     "beforeDevCommand": "npm run dev -- --host 127.0.0.1",

--- a/apps/shield-gui/src/hooks/use-about-page.ts
+++ b/apps/shield-gui/src/hooks/use-about-page.ts
@@ -10,7 +10,7 @@ type AppInfo = {
 };
 
 const defaultAppInfo: AppInfo = {
-  version: "1.2.7-rc.5",
+  version: "1.2.7",
   git_hash: "dev",
   build_date: "unknown",
 };

--- a/crates/shield-core/Cargo.toml
+++ b/crates/shield-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shield-core"
-version = "1.2.7-rc.5"
+version = "1.2.7"
 edition = "2021"
 authors = ["MocikaDev"]
 license = "MIT"

--- a/shield-stub/compat/api19-rust/Cargo.toml
+++ b/shield-stub/compat/api19-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mocikashield-api19"
-version = "1.2.7-rc.5"
+version = "1.2.7"
 edition = "2021"
 build = "../../src/main/rust/build.rs"
 

--- a/shield-stub/src/main/rust/Cargo.toml
+++ b/shield-stub/src/main/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mocikashield"
-version = "1.2.7-rc.5"
+version = "1.2.7"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
## 版本说明

`1.2.7` 是一次 Android 运行兼容性与安全检查集中收口版本，正式版代码与已经完成设备矩阵验证的 `1.2.7-rc.5` 一致。

## 主要变化

- 支持 Android 5.0～6.0 旧版 ART DEX 注入
- 提供 Android 4.4 工控兼容模式，Android 4.4.2 `armeabi-v7a`/NEON 真机已确认正常运行
- 修复 ARouter 首次安装及清除数据后的路由初始化问题
- 修复 Android 9 `org.apache.http.legacy` 类加载冲突
- 修复 `extractNativeLibs=false` 场景的 Native 库打包与安装问题
- 完善 4 KB / 16 KB ZIP 对齐和 Native ELF 校验
- 每次进程启动在读取 DEX 缓存前执行安全检查，解密入口保留纵深检查

## 验证

- `cargo check --workspace`
- `bash scripts/check-release-ready.sh`
- RC.5 三平台 Release 构建及设备矩阵已通过