### PR TITLE
fix: 同步Android 4.4兼容锁文件版本

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-andro
 ```
 
 ### 版本号同步
-升级时优先使用 `scripts/bump-version.sh`，同步 `crates/shield-core/Cargo.toml`、`apps/shield-cli/Cargo.toml`、`shield-stub/src/main/rust/Cargo.toml`、`shield-stub/compat/api19-rust/Cargo.toml`、`apps/shield-gui/src-tauri/Cargo.toml`、`apps/shield-gui/src-tauri/tauri.conf.json`、`apps/shield-gui/package.json` 和 `apps/shield-gui/package-lock.json`。
+升级时优先使用 `scripts/bump-version.sh`，同步 `crates/shield-core/Cargo.toml`、`apps/shield-cli/Cargo.toml`、`shield-stub/src/main/rust/Cargo.toml`、`shield-stub/compat/api19-rust/Cargo.toml` 及其独立 `Cargo.lock`、`apps/shield-gui/src-tauri/Cargo.toml`、`apps/shield-gui/src-tauri/tauri.conf.json`、`apps/shield-gui/package.json` 和 `apps/shield-gui/package-lock.json`。API 19 发布构建使用 `--locked`，不得只修改兼容清单而遗漏独立锁文件。
 
 ### DEXB v5 格式
 加密 DEX 以 MSHD 块追加到 `classes.dex` 末尾（DEX `file_size` 之外，工具不可见）。

--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -90,6 +90,8 @@ Pull Request 合并前必须通过以下 CI 检查：
 | `crates/shield-core/Cargo.toml` | `version = "x.y.z[-pre]"` |
 | `apps/shield-cli/Cargo.toml` | `version = "x.y.z[-pre]"` |
 | `shield-stub/src/main/rust/Cargo.toml` | `version = "x.y.z[-pre]"` |
+| `shield-stub/compat/api19-rust/Cargo.toml` | `version = "x.y.z[-pre]"` |
+| `shield-stub/compat/api19-rust/Cargo.lock` | 独立兼容 crate 的根包版本；发布构建使用 `--locked` |
 | `apps/shield-gui/src-tauri/Cargo.toml` | `version = "x.y.z[-pre]"` |
 | `apps/shield-gui/src-tauri/tauri.conf.json` | `"version": "x.y.z[-pre]"` |
 | `apps/shield-gui/package.json` | `"version": "x.y.z[-pre]"` |
@@ -102,7 +104,7 @@ bash scripts/bump-version.sh x.y.z
 bash scripts/bump-version.sh x.y.z-rc.1
 ```
 
-修改后需重新运行 `cargo build` 或 `make build-all` 使 `Cargo.lock` 同步更新。
+脚本会使用 Rust 1.77.2 离线同步 API 19 兼容 crate 的独立锁文件；修改后仍需运行 `cargo build` 或 `make build-all`，使根 `Cargo.lock` 同步更新。
 
 ---
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -11,6 +11,8 @@
 #   apps/shield-cli/Cargo.toml
 #   apps/shield-gui/src-tauri/Cargo.toml
 #   shield-stub/src/main/rust/Cargo.toml
+#   shield-stub/compat/api19-rust/Cargo.toml
+#   shield-stub/compat/api19-rust/Cargo.lock
 #   apps/shield-gui/src-tauri/tauri.conf.json
 #   apps/shield-gui/package.json
 #   apps/shield-gui/package-lock.json
@@ -58,6 +60,15 @@ echo "  ✓ shield-stub/src/main/rust/Cargo.toml"
 
 si "s/^version = \"[^\"]*\"/version = \"$VERSION\"/" "$ROOT/shield-stub/compat/api19-rust/Cargo.toml"
 echo "  ✓ shield-stub/compat/api19-rust/Cargo.toml"
+
+# API 19 兼容 crate 使用独立 workspace 和锁文件，Release 构建会传入 --locked。
+# 只更新本地根 package 版本，不解析或升级任何第三方依赖。
+cargo +1.77.2 update \
+  --manifest-path "$ROOT/shield-stub/compat/api19-rust/Cargo.toml" \
+  --package mocikashield-api19 \
+  --precise "$VERSION" \
+  --offline
+echo "  ✓ shield-stub/compat/api19-rust/Cargo.lock"
 
 # tauri.conf.json 顶层 "version" 字段缩进固定为 2 空格
 si "s/^  \"version\": \"[^\"]*\"/  \"version\": \"$VERSION\"/" "$ROOT/apps/shield-gui/src-tauri/tauri.conf.json"

--- a/shield-stub/compat/api19-rust/Cargo.lock
+++ b/shield-stub/compat/api19-rust/Cargo.lock
@@ -242,7 +242,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mocikashield-api19"
-version = "1.2.7-rc.5"
+version = "1.2.7"
 dependencies = [
  "chacha20poly1305",
  "hkdf",


### PR DESCRIPTION
## 问题

`1.2.7` 版本同步更新了 API 19 兼容 crate 的 `Cargo.toml`，但遗漏其独立 `Cargo.lock`。Release 构建使用 `--locked`，因此三平台在构建 Android 4.4 资源时拒绝继续。

## 修复

- 同步 `shield-stub/compat/api19-rust/Cargo.lock` 根包版本到 `1.2.7`
- `bump-version.sh` 使用 Rust 1.77.2 离线同步独立锁文件
- 文档和项目约束补充独立锁文件要求

## 验证

- `bash scripts/bump-version.sh 1.2.7`
- `cargo +1.77.2 metadata --manifest-path shield-stub/compat/api19-rust/Cargo.toml --locked --offline --no-deps`
- `git diff --check`