### PR TITLE
fix: 移除语义重复的Native别名

### DIFF
--- a/crates/shield-core/src/protect/native_alias.rs
+++ b/crates/shield-core/src/protect/native_alias.rs
@@ -29,8 +29,8 @@ const ALIAS_BODIES: &[&str] = &[
     "commonutilmodule",
     "modulecorebridge",
     "moduledatabridge",
-    "modulebasemodule",
-    "moduleutilmodule",
+    "modulebasebridge",
+    "moduleutilbridge",
     "enginecorebridge",
     "enginedatabridge",
     "enginebasemodule",
@@ -332,6 +332,12 @@ mod tests {
             assert!(is_lower_ascii_name(body), "非法候选: {body}");
             for forbidden in ["mocika", "shield", "protect", "packer", "shell", "bugly"] {
                 assert!(!body.contains(forbidden), "候选包含禁用词: {body}");
+            }
+            for role in ["native", "common", "module", "engine", "runtime", "support"] {
+                assert!(
+                    !(body.starts_with(role) && body.ends_with(role)),
+                    "候选首尾角色词重复: {body}"
+                );
             }
         }
     }


### PR DESCRIPTION
## 修复内容

- 移除首尾重复 `module` 的两个 Native 别名候选
- 增加角色词首尾重复检查，防止再次生成类似名称

## 验证

- Native 别名测试 7 项通过
- shield-core 严格静态检查通过