### PR TITLE
fix: 兼容 JDK 8 证书指纹读取

### DIFF
--- a/crates/shield-core/src/apk_inspect.rs
+++ b/crates/shield-core/src/apk_inspect.rs
@@ -174,6 +174,8 @@ pub fn extract_keystore_cert_fingerprint(
     let keytool = find_keytool()?;
 
     let mut args = vec![
+        "-J-Duser.language=en",
+        "-J-Duser.country=US",
         "-list",
         "-v",
         "-keystore",
@@ -198,10 +200,17 @@ pub fn extract_keystore_cert_fingerprint(
         if let Some(fp) = parse_sha256_from_keytool(&stdout) {
             return Ok(fp);
         }
+        anyhow::bail!("keytool 已执行成功，但未返回可识别的 SHA-256 指纹")
     }
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    anyhow::bail!("无法读取 keystore 证书指纹：{}", stderr.trim())
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let detail = if stderr.trim().is_empty() {
+        stdout.trim()
+    } else {
+        stderr.trim()
+    };
+    anyhow::bail!("无法读取 keystore 证书指纹：{detail}")
 }
 
 pub fn normalize_fingerprint(fp: &str) -> String {


### PR DESCRIPTION
## 问题

JDK 8 的本地化 keytool 输出格式与新版本不同。命令执行成功后，核心层无法识别 SHA-256 指纹，导致加固页证书比对失败并显示空错误详情。

## 修复

- 指纹读取命令固定使用英文区域输出，兼容 JDK 8 与后续版本
- keytool 成功但无可识别指纹时返回明确错误
- keytool 失败且 stderr 为空时回退展示 stdout

## 验证

- Corretto 8 keytool 返回标准 SHA-256 指纹
- cargo test -p shield-core：93 项通过
- cargo clippy -p shield-core --all-targets -- -D warnings
- JDK 8 GUI 加固与自动签名成功
- 产物 ZIP 完整，apksigner v2/v3 校验通过