### PR TITLE
fix: 检测已启用的ADB Root环境

### DIFF
--- a/docs/design/runtime-security.md
+++ b/docs/design/runtime-security.md
@@ -195,7 +195,7 @@ Manifest 字段：
 
 ### Root 信号分级
 
-严格模式只根据高置信度组合阻止启动，例如明确可执行的 `su`、Magisk/Zygisk/KernelSU/APatch 注入或挂载痕迹、异常 UID 等。`test-keys`、`userdebug/eng`、`ro.debuggable`、模拟器特征和单个可疑路径属于弱信号，不能单独触发阻止。
+严格模式只根据高置信度组合阻止启动，例如明确可执行的 `su`、Magisk/Zygisk/KernelSU/APatch 注入或挂载痕迹、异常 UID，以及明确为 `service.adb.root=1` 的 Root ADB 等。`test-keys`、`userdebug/eng`、`ro.debuggable`、模拟器特征和单个可疑路径属于弱信号，不能单独触发阻止。
 
 Native 内部可返回位标志用于自动化测试，但 Java 和业务日志只获得通用结果，避免暴露规则细节。
 
@@ -299,7 +299,7 @@ Root 策略范围：
 - 接入 `compatible/strict` 枚举、Manifest 配置流和 GUI 任务级选项。
 - CLI 与旧请求保持默认兼容。
 
-当前实现状态：核心固定枚举、资源能力握手、Manifest 配置、GUI 任务级选项及 Native 高置信 Root 信号已接通；兼容模式维持原有反调试行为，严格模式额外拒绝 Root 信号。标准/API 19 双资源构建完成，API 35 普通真机已通过严格模式双 DEX、真实 Application、同签名覆盖安装、首次启动和二次启动验证；可控 Root 环境命中仍待具备条件的设备补测。
+当前实现状态：核心固定枚举、资源能力握手、Manifest 配置、GUI 任务级选项及 Native 高置信 Root 信号已接通；兼容模式维持原有反调试行为，严格模式额外拒绝 Root 信号。标准/API 19 双资源构建完成。API 35 普通真机已通过严格模式双 DEX、真实 Application、同签名覆盖安装、首次启动和二次启动验证；同一台 LineageOS 开启 Root ADB 后，严格模式按 `service.adb.root=1` 正确拒绝启动，兼容模式仍可完成首次和二次启动。
 
 内存 DEX 实验范围：
 

--- a/shield-stub/src/main/rust/src/root_environment.rs
+++ b/shield-stub/src/main/rust/src/root_environment.rs
@@ -4,6 +4,16 @@ use std::fs;
 use std::io::{BufRead, BufReader};
 use std::os::unix::fs::PermissionsExt;
 
+#[cfg(target_os = "android")]
+use std::ffi::CStr;
+#[cfg(target_os = "android")]
+use std::os::raw::{c_char, c_int};
+
+#[cfg(target_os = "android")]
+extern "C" {
+    fn __system_property_get(name: *const c_char, value: *mut c_char) -> c_int;
+}
+
 const SU_PATHS: &[&str] = &[
     "/system/bin/su",
     "/system/xbin/su",
@@ -15,7 +25,31 @@ const SU_PATHS: &[&str] = &[
 const INJECTION_SIGNATURES: &[&str] = &["magisk", "zygisk", "kernelsu", "apatch"];
 
 pub fn check() -> bool {
-    has_executable_su() || has_privileged_uid() || has_root_injection_trace()
+    has_executable_su() || has_privileged_uid() || has_root_adb() || has_root_injection_trace()
+}
+
+#[cfg(target_os = "android")]
+fn has_root_adb() -> bool {
+    const PROPERTY_NAME: &[u8] = b"service.adb.root\0";
+    // Android 系统属性值上限为 91 字节，额外保留结尾零字节。
+    let mut value = [0 as c_char; 92];
+    let length = unsafe {
+        __system_property_get(PROPERTY_NAME.as_ptr().cast::<c_char>(), value.as_mut_ptr())
+    };
+    if length <= 0 {
+        return false;
+    }
+    let value = unsafe { CStr::from_ptr(value.as_ptr()) };
+    value.to_str().map(is_root_adb_value).unwrap_or(false)
+}
+
+#[cfg(not(target_os = "android"))]
+fn has_root_adb() -> bool {
+    false
+}
+
+fn is_root_adb_value(value: &str) -> bool {
+    value == "1"
 }
 
 fn has_executable_su() -> bool {
@@ -73,5 +107,13 @@ mod tests {
         );
         assert_eq!(effective_uid("Uid:\t0\t0\t0\t0\n"), Some(0));
         assert_eq!(effective_uid("Name:\tapp\n"), None);
+    }
+
+    #[test]
+    fn 仅明确开启的_adb_root_属性命中() {
+        assert!(is_root_adb_value("1"));
+        assert!(!is_root_adb_value("0"));
+        assert!(!is_root_adb_value(""));
+        assert!(!is_root_adb_value("true"));
     }
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,6 +21,13 @@ RUN_DEVICE_TEST=1 bash tests/scripts/run-protect-e2e.sh
 ENVIRONMENT_POLICY=strict RUN_DEVICE_TEST=1 bash tests/scripts/run-protect-e2e.sh
 ```
 
+已通过 `adb root` 获得 Root ADB 的 LineageOS 等设备，应要求严格策略拒绝加固包启动：
+
+```bash
+ENVIRONMENT_POLICY=strict EXPECT_PROTECTED_REJECTION=1 RUN_DEVICE_TEST=1 \
+  bash tests/scripts/run-protect-e2e.sh
+```
+
 存在多个在线设备时通过 `ANDROID_SERIAL` 指定目标设备。测试证书只在系统临时目录中生成，脚本退出时自动清理，不向仓库提交任何私钥。日常 CI 不启动模拟器；真实运行时回归由维护者在真机或指定模拟器上按需执行。
 
 ## Android 4.4 Native 加载探针

--- a/tests/scripts/run-protect-e2e.sh
+++ b/tests/scripts/run-protect-e2e.sh
@@ -103,6 +103,26 @@ verify_launch() {
   return 1
 }
 
+verify_rejected() {
+  local scenario="$1"
+  "${ADB_COMMAND[@]}" logcat -c
+  "${ADB_COMMAND[@]}" shell am force-stop "$PACKAGE_NAME" >/dev/null 2>&1 || true
+  "${ADB_COMMAND[@]}" shell am start -W -n "$COMPONENT" >/dev/null 2>&1 || true
+  for _ in $(seq 1 15); do
+    local logs
+    logs="$("${ADB_COMMAND[@]}" logcat -d -s AndroidRuntime:E '*:S')"
+    if grep -q 'SecurityException: S01' <<< "$logs" \
+      && ! grep -q 'MOCIKA_SMOKE_APPLICATION_OK' <<< "$logs"; then
+      echo "$scenario 验证通过"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "错误：$scenario 未观察到环境策略拒绝" >&2
+  "${ADB_COMMAND[@]}" logcat -d -s AndroidRuntime:E '*:S' >&2
+  return 1
+}
+
 if [[ "${RUN_DEVICE_TEST:-0}" == "1" ]]; then
   command -v adb >/dev/null || { echo "缺少命令：adb" >&2; exit 1; }
   ADB_COMMAND=(adb)
@@ -115,8 +135,12 @@ if [[ "${RUN_DEVICE_TEST:-0}" == "1" ]]; then
   "${ADB_COMMAND[@]}" install "$SIGNED" | grep -q '^Success'
   verify_launch "未加固双 DEX 基线"
   "${ADB_COMMAND[@]}" install -r "$FINAL" | grep -q '^Success'
-  verify_launch "同签名覆盖安装加固包首次启动"
-  verify_launch "加固包缓存命中后二次启动"
+  if [[ "${EXPECT_PROTECTED_REJECTION:-0}" == "1" ]]; then
+    verify_rejected "严格策略拒绝 Root 环境"
+  else
+    verify_launch "同签名覆盖安装加固包首次启动"
+    verify_launch "加固包缓存命中后二次启动"
+  fi
 fi
 
 echo "端到端加固回归测试通过"


### PR DESCRIPTION
## 变更内容

- Native Root 检测新增 `service.adb.root=1` 高置信信号
- `ro.debuggable`、`userdebug` 等弱信号仍不单独阻止启动
- 真机回归脚本支持断言严格策略应拒绝 Root 环境
- 更新运行时安全设计和维护者测试命令

## 验证

- Native 单元测试 15 项通过
- 标准与 Android 4.4 双资源构建通过
- LineageOS API 35、`adb root`、`service.adb.root=1`：严格策略命中 `S01` 并拒绝启动
- 同一设备兼容策略：双 DEX、真实 Application、首次启动和缓存命中后二次启动通过

## 边界

不扫描 `adbd` 进程、不执行 `getprop` 子进程，不改变 GUI、核心协议或兼容模式默认行为。