### PR TITLE
chore: 准备1.3.0-alpha.2发布

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "mocika-shield"
-version = "1.3.0-alpha.1"
+version = "1.3.0-alpha.2"
 dependencies = [
  "chacha20poly1305",
  "dunce",
@@ -2168,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "mocikashield"
-version = "1.3.0-alpha.1"
+version = "1.3.0-alpha.2"
 dependencies = [
  "chacha20poly1305",
  "hkdf",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "shield-cli"
-version = "1.3.0-alpha.1"
+version = "1.3.0-alpha.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "shield-core"
-version = "1.3.0-alpha.1"
+version = "1.3.0-alpha.2"
 dependencies = [
  "anyhow",
  "chacha20poly1305",

--- a/apps/shield-cli/Cargo.toml
+++ b/apps/shield-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shield-cli"
-version = "1.3.0-alpha.1"
+version = "1.3.0-alpha.2"
 edition = "2021"
 authors = ["MocikaDev"]
 license = "MIT"

--- a/apps/shield-gui/package-lock.json
+++ b/apps/shield-gui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mocika-shield-gui",
-  "version": "1.3.0-alpha.1",
+  "version": "1.3.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mocika-shield-gui",
-      "version": "1.3.0-alpha.1",
+      "version": "1.3.0-alpha.2",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.19",
         "@radix-ui/react-label": "^2.1.11",

--- a/apps/shield-gui/package.json
+++ b/apps/shield-gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocika-shield-gui",
-  "version": "1.3.0-alpha.1",
+  "version": "1.3.0-alpha.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/shield-gui/src-tauri/Cargo.toml
+++ b/apps/shield-gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mocika-shield"
-version = "1.3.0-alpha.1"
+version = "1.3.0-alpha.2"
 edition = "2021"
 publish = false
 description = "Mocika Shield APK 加固工具桌面 GUI"

--- a/apps/shield-gui/src-tauri/tauri.conf.json
+++ b/apps/shield-gui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MocikaShield",
-  "version": "1.3.0-alpha.1",
+  "version": "1.3.0-alpha.2",
   "identifier": "dev.mocika.shield-gui",
   "build": {
     "beforeDevCommand": "npm run dev -- --host 127.0.0.1",

--- a/apps/shield-gui/src/hooks/use-about-page.ts
+++ b/apps/shield-gui/src/hooks/use-about-page.ts
@@ -10,7 +10,7 @@ type AppInfo = {
 };
 
 const defaultAppInfo: AppInfo = {
-  version: "1.3.0-alpha.1",
+  version: "1.3.0-alpha.2",
   git_hash: "dev",
   build_date: "unknown",
 };

--- a/crates/shield-core/Cargo.toml
+++ b/crates/shield-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shield-core"
-version = "1.3.0-alpha.1"
+version = "1.3.0-alpha.2"
 edition = "2021"
 authors = ["MocikaDev"]
 license = "MIT"

--- a/shield-stub/compat/api19-rust/Cargo.lock
+++ b/shield-stub/compat/api19-rust/Cargo.lock
@@ -242,7 +242,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mocikashield-api19"
-version = "1.3.0-alpha.1"
+version = "1.3.0-alpha.2"
 dependencies = [
  "chacha20poly1305",
  "hkdf",

--- a/shield-stub/compat/api19-rust/Cargo.toml
+++ b/shield-stub/compat/api19-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mocikashield-api19"
-version = "1.3.0-alpha.1"
+version = "1.3.0-alpha.2"
 edition = "2021"
 build = "../../src/main/rust/build.rs"
 

--- a/shield-stub/src/main/rust/Cargo.toml
+++ b/shield-stub/src/main/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mocikashield"
-version = "1.3.0-alpha.1"
+version = "1.3.0-alpha.2"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
## 变更内容

- 将核心、命令行、Android 壳和桌面端版本同步到 `1.3.0-alpha.2`
- 同步根工作区、Android 4.4 兼容资源及前端锁文件
- 更新关于页回退版本号

## 验证

- `cargo check --workspace --locked`
- `npm --prefix apps/shield-gui run build`
- `git diff --check`

## 发布顺序

PR 合并后从合并后的 `main` 创建并推送 `v1.3.0-alpha.2` 标签，由发布工作流构建三平台预发布包。