### PR TITLE
fix: 排除资源包中的macOS元数据

### DIFF
--- a/scripts/build-android-api19-resources.sh
+++ b/scripts/build-android-api19-resources.sh
@@ -78,6 +78,8 @@ WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mocika-api19-resources.XXXXXX")"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
 unzip -q "$STANDARD_RESOURCES" -d "$WORK_DIR"
+find "$WORK_DIR" -type f -name '.DS_Store' -delete
+rm -rf "$WORK_DIR/__MACOSX"
 cp "$API19_OUTPUT/jniLibs/armeabi-v7a/libmocikashield.so" \
     "$WORK_DIR/lib/armeabi-v7a/libmocikashield.so"
 perl -pi -e 's/"min_android_api": 21/"min_android_api": 19/' "$WORK_DIR/metadata.json"

--- a/scripts/build-stub.sh
+++ b/scripts/build-stub.sh
@@ -384,7 +384,8 @@ cd "$OUTPUT_DIR"
 RESOURCES_ZIP="mocika-runtime-resources-${BUILD_VERSION}.zip"
 
 rm -f "$RESOURCES_ZIP" resources.zip
-zip -r "$RESOURCES_ZIP" stub-classes.dex lib/ metadata.json > /dev/null
+zip -r "$RESOURCES_ZIP" stub-classes.dex lib/ metadata.json \
+    -x '*.DS_Store' '__MACOSX/*' > /dev/null
 
 if [ $? -eq 0 ]; then
     RESOURCES_SIZE=$(du -h "$RESOURCES_ZIP" | cut -f1)

--- a/scripts/tests/test_android_api19_build_contract.py
+++ b/scripts/tests/test_android_api19_build_contract.py
@@ -36,6 +36,7 @@ class AndroidApi19BuildContractTests(unittest.TestCase):
         content = (ROOT / "scripts/build-android-api19-resources.sh").read_text(
             encoding="utf-8"
         )
+        standard_content = (ROOT / "scripts/build-stub.sh").read_text(encoding="utf-8")
         commands = [line.strip() for line in content.splitlines()]
         self.assertNotIn('sdkmanager "ndk;25.2.9519653"', commands)
         self.assertFalse(any(line.startswith("rustup toolchain install") for line in commands))
@@ -43,6 +44,9 @@ class AndroidApi19BuildContractTests(unittest.TestCase):
         self.assertIn("Compress-Archive -Path $files", content)
         self.assertIn('$ErrorActionPreference = "Stop"', content)
         self.assertIn('zip -qr "$LEGACY_RESOURCES"', content)
+        self.assertIn("-x '*.DS_Store' '__MACOSX/*'", standard_content)
+        self.assertIn("find \"$WORK_DIR\" -type f -name '.DS_Store' -delete", content)
+        self.assertIn('rm -rf "$WORK_DIR/__MACOSX"', content)
         self.assertNotIn("jar --create", content)
         self.assertIn('unzip -tq "$LEGACY_RESOURCES"', content)
         self.assertIn('"min_android_api": 19', content)


### PR DESCRIPTION
## 问题

本地 macOS 发布构建中，`build/jniLibs` 残留的 `.DS_Store` 会被标准资源包收集，并进一步进入 Android 4.4 兼容资源包。CI 使用干净检出通常不会触发，但本地发布产物不应依赖构建目录恰好干净。

## 修复

- 标准资源 ZIP 排除 `.DS_Store` 与 `__MACOSX`
- Android 4.4 资源重打包前再次清理 macOS 元数据
- 构建契约测试锁定两层过滤规则

## 验证

- `python3 -m unittest scripts.tests.test_android_api19_build_contract -v`
- `make build-stub`
- 在本地残留 `.DS_Store` 的环境中扫描标准/API 19 两个 ZIP，均未发现 macOS 元数据
- `git diff --check`