### PR TITLE
docs: 对齐发布说明自动生成结构

### DIFF
--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -251,9 +251,8 @@ Release Notes 生成规则：
 1. `下载 / Downloads`
 2. `使用须知 / Notes`
 3. `本次变更 / What's Changed`
-4. `完整变更 / Full Changelog`
 
-Release Notes 只保留下载入口、必要运行条件、安全边界和本版本变更，不重复 README 中的完整功能介绍。人工精简发布说明时，可以把自动列表整理成 2～5 条中英文版本亮点，但必须放在 `本次变更 / What's Changed` 下，不得改名或删除固定章节。编辑完成后使用 `gh release view <tag> --json body --jq '.body'` 复核章节；若之后重新运行同一个 tag 的发布任务，自动生成内容会覆盖人工修改，需要再次检查固定章节和版本亮点。
+Release Notes 末尾同时保留 GitHub 生成的 `Full Changelog` 比较链接，但不要求它作为独立章节。Release Notes 只保留下载入口、必要运行条件、安全边界和本版本变更，不重复 README 中的完整功能介绍。人工精简发布说明时，可以把自动列表整理成 2～5 条中英文版本亮点，但必须放在 `本次变更 / What's Changed` 下，不得改名或删除固定章节。编辑完成后使用 `gh release view <tag> --json body --jq '.body'` 复核章节；若之后重新运行同一个 tag 的发布任务，自动生成内容会覆盖人工修改，需要再次检查固定章节和版本亮点。
 
 ### 手动触发发布
 


### PR DESCRIPTION
## 变更内容

- 固定下载、使用须知、本次变更三个中英文章节
- 明确完整变更由 GitHub 比较链接提供，不强制作为独立章节
- 使流程规范与当前自动生成产物保持一致

## 检查

- `git diff --check`