### PR TITLE
fix: 移除发布说明重复变更标题

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,10 +347,14 @@ jobs:
             > generated-release-notes.json
 
           jq -r '.body' generated-release-notes.json > generated-release-notes-body.md
+          awk '
+            !removed && /^## What.s Changed$/ { removed = 1; next }
+            { print }
+          ' generated-release-notes-body.md > generated-release-notes-normalized.md
 
           cat release-notes-prefix.md > release-notes.md
           printf '\n\n---\n\n' >> release-notes.md
-          cat generated-release-notes-body.md >> release-notes.md
+          cat generated-release-notes-normalized.md >> release-notes.md
 
       - name: 创建或更新 GitHub Release
         shell: bash

--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -245,6 +245,7 @@ Release Notes 生成规则：
 - 如果存在 `.github/release-notes/versions/x.y.z.md`，在固定“本次变更”章节下插入该版本系列的人工中英文能力汇总；同一系列的 Alpha、Beta、RC 和正式版复用该文件
 - 再查找当前标签之前最近一个已公开正式版本，作为 GitHub Release Notes API 的固定比较基线
 - Alpha、Beta、RC 和最终正式版均汇总相对上一正式版本的完整版本周期变更，不以相邻预发布标签作为比较基线
+- 合并自动变更列表前移除 GitHub 自带的 `What's Changed` 标题，避免与固定中英文章节重复；分类标题和 `Full Changelog` 保持不变
 - 最终将两部分合并后写入 Release
 - 如果重新运行同一个 tag 的发布任务，产物与 Release Notes 会一并更新
 


### PR DESCRIPTION
## 变更内容

- 合并 GitHub 自动变更列表前移除其首个 `What's Changed` 标题
- 保留分类标题、提交列表和 `Full Changelog`
- 补充发布流程文档约束

## 验证

- Release workflow YAML 解析通过
- 模拟自动生成内容验证只移除重复标题
- `git diff --check` 通过