### PR TITLE
test: 对比内存DEX加载器接入方式

### DIFF
--- a/docs/design/runtime-security.md
+++ b/docs/design/runtime-security.md
@@ -268,7 +268,7 @@ BootClassLoader
 └── InMemoryDexClassLoader：负责全部业务 DEX，并继承原应用 Native 搜索目录
 ```
 
-业务加载器的 parent 必须是原 `PathClassLoader` 的 parent，不能把原加载器作为 parent。否则原 APK 中尚未抽离或重复存在的业务类会被父优先委派提前定义，重新形成双加载器类身份。正式接入前还必须证明壳类与业务类集合不存在交叉；无法稳定分离时停止该方案。
+反射替换路径中，业务加载器的 parent 必须是原 `PathClassLoader` 的 parent，不能把原加载器作为 parent。否则原 APK 中尚未抽离或重复存在的业务类会被父优先委派提前定义，重新形成双加载器类身份。使用 `AppComponentFactory` 公开入口时存在不同约束：工厂类和壳 Application 已由系统默认加载器定义，返回的业务加载器需要以默认加载器为 parent 才能继续实例化壳组件。因此正式资源必须保证默认加载器只包含壳类、业务 DEX 只存在于内存载荷，两者类集合不交叉；无法稳定分离时停止该方案。
 
 `InMemoryDexClassLoader` 的 `librarySearchPath` 必须继承原 APK 的完整 Native 搜索语义。只传 `ApplicationInfo.nativeLibraryDir` 无法覆盖 `extractNativeLibs=false` 时直接从 APK 加载 `.so` 的路径；至少需要包含 `sourceDir!/lib/<ABI>`、应用 Native 目录和系统公开库路径，并验证任务级别名壳库与原业务库均可加载。路径无法从公开稳定信息重建时，不允许接入生产资源。
 
@@ -305,6 +305,22 @@ BootClassLoader
 - API 29、API 35 16 KB、API 36 的性能和内存矩阵
 
 探针通过不改变正式能力：`metadata.json` 继续保持 `memory_dex: false`，标准/API 19 资源与 GUI 均不接入该路径。
+
+#### `AppComponentFactory` 与反射入口对照
+
+2026-07-30 在同一 API 35 真机和同一组双 DEX 载荷上，将隔离探针拆成两个构建变体：
+
+1. 反射变体继续在壳 Application 的 `attachBaseContext()` 中写入 `LoadedApk.mClassLoader`。
+2. 工厂变体通过公开的 `AppComponentFactory.instantiateClassLoader()` 返回业务 `InMemoryDexClassLoader`，不反射修改框架 ClassLoader 字段。
+
+两种变体均在主进程和远程 Service 进程通过真实 Application、Provider、Activity、Service、跨 DEX 引用、APK 内 Native 库、GC 后延迟首次加载和私有目录无 DEX 检查。公开工厂入口由系统在 Application Context 初始化和任何应用组件实例化前调用，加载器时序与框架契约更明确，因此作为下一阶段首选；反射路径只保留为对照和止损依据，不进入正式实现。
+
+公开入口仍有两个生产阻塞项：
+
+- 回调只有默认 ClassLoader 与 `ApplicationInfo`，尚无可用 `Context`。当前 DEXB v5 解密必须通过 `Context` 读取设备实际签名，不能原样前移；必须先设计不降低签名绑定强度的早期证书读取边界。
+- 原应用可能声明 AndroidX 或自定义 `AppComponentFactory`。壳工厂不能直接覆盖其 Application、Activity、Service、Receiver 和 Provider 实例化语义；必须验证加载业务 DEX 后的安全委托方案，并处理委托工厂创建失败和递归配置。
+
+这两个阻塞项未通过前，不把工厂探针接入正式 Stub，也不开放 `memory_dex` 能力字段。
 
 ## 任务阶段与版本规划
 

--- a/docs/process/roadmap.md
+++ b/docs/process/roadmap.md
@@ -61,7 +61,7 @@
 | 认证缓存与资源能力 | `alpha.1` 候选完成 | 摘要、原子重建、协议握手、异常缓存自动回归及低版本运行回归已完成 | 发布 `alpha.1` 后收集兼容反馈，不阻塞后续 `alpha.2` 开发 |
 | Root 策略与内存 DEX 实验 | `alpha.2` 已发布 | GUI、核心、Manifest、双资源与兼容/严格策略链路已接通；普通真机和 LineageOS ADB Root 已完成双向回归。API 29+ 原加载器内存注入实验已止损，不合入运行代码 | 已进入 Beta 功能冻结；替换 ClassLoader 方案留待后续独立评估 |
 | `1.3.0` 功能冻结与完整回归 | 已完成 | 全部单元测试、双资源、Stub DEX 指标、端到端加固、普通/Root 双向策略、缓存篡改重建、私有目录隔离和启动耗时均已验证 | 正式版后只在补丁版本处理可复现缺陷，不再改变协议和默认行为 |
-| `1.4.0` 替换 ClassLoader 原型 | 进行中 | API 35 最小双 DEX 探针已通过双进程、四类组件、GC 后延迟加载、APK 内 Native 库和私有目录无 DEX 验证；继续补齐正式 Stub Native、ARouter、Android 9、split、Instrumentation 和回退 | 隔离夹具不进入正式 Stub、GUI 或资源包；完整门槛通过后才发布 `alpha.1` |
+| `1.4.0` 替换 ClassLoader 原型 | 进行中 | API 35 上反射替换与公开 `AppComponentFactory` 入口均通过双进程、四类组件、GC 后延迟加载、APK 内 Native 库和私有目录无 DEX 验证；公开入口作为首选，下一步解决无 Context 时的签名绑定解密和原应用工厂委托，再补齐正式 Stub Native、ARouter、Android 9、split、Instrumentation 和回退 | 隔离夹具不进入正式 Stub、GUI 或资源包；完整门槛通过后才发布 `alpha.1` |
 
 用户诊断中的低风险静态预检可以按真实反馈独立插入，不必等待整条安全主线完成；但不得与高风险壳加载改动混在同一提交或候选版本中。
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -32,7 +32,7 @@ ENVIRONMENT_POLICY=strict EXPECT_PROTECTED_REJECTION=1 RUN_DEVICE_TEST=1 \
 
 ## API 29+ 内存 DEX 加载探针
 
-`fixtures/android-memory-loader-probe` 是隔离研究夹具，不进入正式 Stub 或资源包。它把 Application、Activity、Service、Provider 和跨 DEX 依赖编译到两个独立 DEX 资源中，启动壳只负责创建 `InMemoryDexClassLoader` 并替换框架 `LoadedApk` 持有的应用 ClassLoader。
+`fixtures/android-memory-loader-probe` 是隔离研究夹具，不进入正式 Stub 或资源包。它把 Application、Activity、Service、Provider 和跨 DEX 依赖编译到两个独立 DEX 资源中，并分别构建反射写入 `LoadedApk.mClassLoader` 与公开 `AppComponentFactory.instantiateClassLoader()` 两种入口进行对照。
 
 连接 API 29 及以上设备后执行：
 
@@ -40,7 +40,7 @@ ENVIRONMENT_POLICY=strict EXPECT_PROTECTED_REJECTION=1 RUN_DEVICE_TEST=1 \
 bash tests/scripts/run-memory-loader-probe.sh
 ```
 
-探针必须同时确认主进程与远程 Service 进程分别完成加载器替换，Application、Provider、Activity、Service 与第二 DEX 类均正常创建，APK 内 Native 库可以通过业务类加载，并且 GC 后仍可首次访问延迟类；应用私有目录不得生成完整 DEX 文件。该结果只证明最小框架链路可行，不代表 ARouter、系统共享库、覆盖安装或生产回退已经通过。
+脚本会依次安装两个变体。两者都必须确认主进程与远程 Service 进程分别创建业务加载器，Application、Provider、Activity、Service 与第二 DEX 类均正常创建，APK 内 Native 库可以通过业务类加载，并且 GC 后仍可首次访问延迟类；应用私有目录不得生成完整 DEX 文件。该结果只证明最小框架链路可行，不代表早期签名绑定解密、原应用工厂委托、ARouter、系统共享库、覆盖安装或生产回退已经通过。
 
 ## Android 4.4 Native 加载探针
 

--- a/tests/fixtures/android-memory-loader-probe/app/build.gradle.kts
+++ b/tests/fixtures/android-memory-loader-probe/app/build.gradle.kts
@@ -24,6 +24,16 @@ android {
         }
     }
 
+    flavorDimensions += "loaderEntry"
+    productFlavors {
+        create("reflection") {
+            dimension = "loaderEntry"
+        }
+        create("factory") {
+            dimension = "loaderEntry"
+        }
+    }
+
     sourceSets.getByName("main").assets.srcDir(
         providers.environmentVariable("MEMORY_PROBE_ASSETS").orElse("src/main/empty-assets")
     )

--- a/tests/fixtures/android-memory-loader-probe/app/src/factory/AndroidManifest.xml
+++ b/tests/fixtures/android-memory-loader-probe/app/src/factory/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:appComponentFactory="dev.mocika.shield.memoryprobe.ProbeAppComponentFactory" />
+</manifest>

--- a/tests/fixtures/android-memory-loader-probe/app/src/main/java/dev/mocika/shield/memoryprobe/MemoryPayloadLoader.java
+++ b/tests/fixtures/android-memory-loader-probe/app/src/main/java/dev/mocika/shield/memoryprobe/MemoryPayloadLoader.java
@@ -1,0 +1,66 @@
+package dev.mocika.shield.memoryprobe;
+
+import android.content.pm.ApplicationInfo;
+import android.os.Build;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import dalvik.system.InMemoryDexClassLoader;
+
+/** 仅负责从探针 APK 读取内存 DEX 并创建业务加载器。 */
+final class MemoryPayloadLoader {
+    private static final String[] PAYLOAD_ENTRIES = {
+            "assets/payload-main.dex",
+            "assets/payload-secondary.dex"
+    };
+
+    private MemoryPayloadLoader() {}
+
+    static ClassLoader create(ApplicationInfo info, ClassLoader parent) throws Exception {
+        ByteBuffer[] payload = new ByteBuffer[PAYLOAD_ENTRIES.length];
+        try (ZipFile apk = new ZipFile(info.sourceDir)) {
+            for (int index = 0; index < PAYLOAD_ENTRIES.length; index++) {
+                payload[index] = readDirectBuffer(apk, PAYLOAD_ENTRIES[index]);
+            }
+        }
+        return new InMemoryDexClassLoader(payload, buildNativeSearchPath(info), parent);
+    }
+
+    private static ByteBuffer readDirectBuffer(ZipFile apk, String name) throws Exception {
+        ZipEntry entry = apk.getEntry(name);
+        if (entry == null) {
+            throw new IllegalStateException("MEMORY_PROBE_ASSET_MISSING:" + name);
+        }
+        try (InputStream input = apk.getInputStream(entry);
+             ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] chunk = new byte[16 * 1024];
+            int count;
+            while ((count = input.read(chunk)) >= 0) {
+                output.write(chunk, 0, count);
+            }
+            byte[] bytes = output.toByteArray();
+            ByteBuffer buffer = ByteBuffer.allocateDirect(bytes.length);
+            buffer.put(bytes);
+            buffer.flip();
+            return buffer;
+        }
+    }
+
+    private static String buildNativeSearchPath(ApplicationInfo info) {
+        StringBuilder paths = new StringBuilder();
+        for (String abi : Build.SUPPORTED_ABIS) {
+            if (paths.length() > 0) {
+                paths.append(java.io.File.pathSeparatorChar);
+            }
+            paths.append(info.sourceDir).append("!/lib/").append(abi);
+        }
+        if (info.nativeLibraryDir != null && !info.nativeLibraryDir.isEmpty()) {
+            paths.append(java.io.File.pathSeparatorChar).append(info.nativeLibraryDir);
+        }
+        return paths.toString();
+    }
+}

--- a/tests/fixtures/android-memory-loader-probe/app/src/main/java/dev/mocika/shield/memoryprobe/ProbeAppComponentFactory.java
+++ b/tests/fixtures/android-memory-loader-probe/app/src/main/java/dev/mocika/shield/memoryprobe/ProbeAppComponentFactory.java
@@ -1,0 +1,21 @@
+package dev.mocika.shield.memoryprobe;
+
+import android.app.AppComponentFactory;
+import android.content.pm.ApplicationInfo;
+import android.util.Log;
+
+/** 使用系统公开入口创建探针业务加载器，不进入正式壳。 */
+public final class ProbeAppComponentFactory extends AppComponentFactory {
+    private static final String TAG = "MOCIKA_MEMORY_PROBE";
+
+    @Override
+    public ClassLoader instantiateClassLoader(ClassLoader defaultLoader, ApplicationInfo info) {
+        try {
+            ClassLoader loader = MemoryPayloadLoader.create(info, defaultLoader);
+            Log.i(TAG, "FACTORY_LOADER_CREATED");
+            return loader;
+        } catch (Exception error) {
+            throw new RuntimeException("MEMORY_PROBE_FACTORY_INIT", error);
+        }
+    }
+}

--- a/tests/fixtures/android-memory-loader-probe/app/src/main/java/dev/mocika/shield/memoryprobe/ProbeApplication.java
+++ b/tests/fixtures/android-memory-loader-probe/app/src/main/java/dev/mocika/shield/memoryprobe/ProbeApplication.java
@@ -4,14 +4,10 @@ import android.app.Application;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.os.Bundle;
-import android.os.Build;
 import android.util.Log;
 
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.nio.ByteBuffer;
 
 import dalvik.system.InMemoryDexClassLoader;
 
@@ -24,19 +20,20 @@ public final class ProbeApplication extends Application {
     protected void attachBaseContext(Context base) {
         super.attachBaseContext(base);
         try {
-            exemptHiddenApi();
             ClassLoader original = base.getClassLoader();
-            ByteBuffer[] payload = new ByteBuffer[] {
-                    readDirectBuffer(base, "payload-main.dex"),
-                    readDirectBuffer(base, "payload-secondary.dex")
-            };
-            String nativePath = buildNativeSearchPath(base.getApplicationInfo());
-            ClassLoader replacement = new InMemoryDexClassLoader(
-                    payload, nativePath, original.getParent());
-            replaceFrameworkClassLoader(base, replacement);
-            Thread.currentThread().setContextClassLoader(replacement);
-            realApplication = createRealApplication(base, replacement);
-            Log.i(TAG, "LOADER_REPLACED");
+            ClassLoader businessLoader;
+            if (original instanceof InMemoryDexClassLoader) {
+                businessLoader = original;
+                Log.i(TAG, "LOADER_READY:FACTORY");
+            } else {
+                exemptHiddenApi();
+                businessLoader = MemoryPayloadLoader.create(
+                        base.getApplicationInfo(), original.getParent());
+                replaceFrameworkClassLoader(base, businessLoader);
+                Log.i(TAG, "LOADER_READY:REFLECTION");
+            }
+            Thread.currentThread().setContextClassLoader(businessLoader);
+            realApplication = createRealApplication(base, businessLoader);
         } catch (Exception error) {
             throw new RuntimeException("MEMORY_PROBE_INIT", error);
         }
@@ -59,36 +56,6 @@ public final class ProbeApplication extends Application {
     @Override
     public Context getApplicationContext() {
         return realApplication != null ? realApplication : super.getApplicationContext();
-    }
-
-    private static ByteBuffer readDirectBuffer(Context context, String name) throws Exception {
-        try (InputStream input = context.getAssets().open(name);
-             ByteArrayOutputStream output = new ByteArrayOutputStream()) {
-            byte[] chunk = new byte[16 * 1024];
-            int count;
-            while ((count = input.read(chunk)) >= 0) {
-                output.write(chunk, 0, count);
-            }
-            byte[] bytes = output.toByteArray();
-            ByteBuffer buffer = ByteBuffer.allocateDirect(bytes.length);
-            buffer.put(bytes);
-            buffer.flip();
-            return buffer;
-        }
-    }
-
-    private static String buildNativeSearchPath(ApplicationInfo info) {
-        StringBuilder paths = new StringBuilder();
-        for (String abi : Build.SUPPORTED_ABIS) {
-            if (paths.length() > 0) {
-                paths.append(java.io.File.pathSeparatorChar);
-            }
-            paths.append(info.sourceDir).append("!/lib/").append(abi);
-        }
-        if (info.nativeLibraryDir != null && !info.nativeLibraryDir.isEmpty()) {
-            paths.append(java.io.File.pathSeparatorChar).append(info.nativeLibraryDir);
-        }
-        return paths.toString();
     }
 
     private static void replaceFrameworkClassLoader(Context base, ClassLoader replacement)

--- a/tests/scripts/run-memory-loader-probe.sh
+++ b/tests/scripts/run-memory-loader-probe.sh
@@ -44,36 +44,48 @@ unzip -q "$PROJECT_DIR/payload-secondary/build/outputs/aar/payload-secondary-deb
 cp "$TEMP_DIR/main-dex/classes.dex" "$ASSET_DIR/payload-main.dex"
 cp "$TEMP_DIR/secondary-dex/classes.dex" "$ASSET_DIR/payload-secondary.dex"
 
-MEMORY_PROBE_ASSETS="$ASSET_DIR" "$GRADLE" -p "$PROJECT_DIR" :app:assembleDebug --no-daemon
-APK="$PROJECT_DIR/app/build/outputs/apk/debug/app-debug.apk"
+MEMORY_PROBE_ASSETS="$ASSET_DIR" "$GRADLE" -p "$PROJECT_DIR" \
+  :app:assembleReflectionDebug :app:assembleFactoryDebug --no-daemon
 
-"${ADB[@]}" uninstall "$PACKAGE" >/dev/null 2>&1 || true
-"${ADB[@]}" logcat -c
-"${ADB[@]}" install "$APK" >/dev/null
-"${ADB[@]}" shell am start -W -n "$COMPONENT" >/dev/null
-sleep 2
+run_probe() {
+  local mode="$1"
+  local expected_loader_marker="$2"
+  local apk="$PROJECT_DIR/app/build/outputs/apk/$mode/debug/app-$mode-debug.apk"
 
-LOGS="$("${ADB[@]}" logcat -d -s MOCIKA_MEMORY_PROBE:I AndroidRuntime:E '*:S')"
-printf '%s\n' "$LOGS"
+  "${ADB[@]}" uninstall "$PACKAGE" >/dev/null 2>&1 || true
+  "${ADB[@]}" logcat -c
+  "${ADB[@]}" install "$apk" >/dev/null
+  "${ADB[@]}" shell am start -W -n "$COMPONENT" >/dev/null
+  sleep 2
 
-for marker in LOADER_REPLACED APPLICATION_OK:SECONDARY_OK PROVIDER_OK ACTIVITY_OK:SECONDARY_OK:NATIVE_OK SERVICE_OK DELAYED_OK:AFTER_GC; do
-  if ! grep -Fq "$marker" <<<"$LOGS"; then
-    echo "内存 DEX 加载探针缺少标记：$marker" >&2
+  local logs
+  logs="$("${ADB[@]}" logcat -d -s MOCIKA_MEMORY_PROBE:I AndroidRuntime:E '*:S')"
+  printf '%s\n' "$logs"
+
+  for marker in "$expected_loader_marker" APPLICATION_OK:SECONDARY_OK PROVIDER_OK ACTIVITY_OK:SECONDARY_OK:NATIVE_OK SERVICE_OK DELAYED_OK:AFTER_GC; do
+    if ! grep -Fq "$marker" <<<"$logs"; then
+      echo "$mode 内存 DEX 加载探针缺少标记：$marker" >&2
+      exit 1
+    fi
+  done
+
+  local loader_process_count
+  loader_process_count="$(grep -F "$expected_loader_marker" <<<"$logs" | awk '{print $3}' | sort -u | wc -l | tr -d ' ')"
+  if (( loader_process_count < 2 )); then
+    echo "$mode 内存 DEX 加载探针未在主进程和远程 Service 进程分别创建加载器" >&2
     exit 1
   fi
-done
 
-LOADER_PROCESS_COUNT="$(grep -F "LOADER_REPLACED" <<<"$LOGS" | awk '{print $3}' | sort -u | wc -l | tr -d ' ')"
-if (( LOADER_PROCESS_COUNT < 2 )); then
-  echo "内存 DEX 加载探针未在主进程和远程 Service 进程分别替换加载器" >&2
-  exit 1
-fi
+  local private_dex
+  private_dex="$("${ADB[@]}" shell run-as "$PACKAGE" find . -type f -name '*.dex' 2>/dev/null | tr -d '\r')"
+  if [[ -n "$private_dex" ]]; then
+    echo "$mode 探针在应用私有目录发现明文 DEX：" >&2
+    printf '%s\n' "$private_dex" >&2
+    exit 1
+  fi
+}
 
-PRIVATE_DEX="$("${ADB[@]}" shell run-as "$PACKAGE" find . -type f -name '*.dex' 2>/dev/null | tr -d '\r')"
-if [[ -n "$PRIVATE_DEX" ]]; then
-  echo "应用私有目录发现明文 DEX：" >&2
-  printf '%s\n' "$PRIVATE_DEX" >&2
-  exit 1
-fi
+run_probe reflection "LOADER_READY:REFLECTION"
+run_probe factory "LOADER_READY:FACTORY"
 
-echo "API $SDK_INT 替换 ClassLoader 内存双 DEX 探针通过，应用私有目录未发现 DEX 文件"
+echo "API $SDK_INT 两种 ClassLoader 入口的内存双 DEX 探针均通过，应用私有目录未发现 DEX 文件"


### PR DESCRIPTION
## 变更内容

- 为 API 29+ 内存 DEX 隔离探针增加反射入口与 `AppComponentFactory` 公开入口两个构建变体
- 抽出探针内部的内存载荷读取与加载器创建职责
- 在同一脚本中依次验证两个变体的双进程、四类组件、双 DEX、Native 加载、GC 后延迟加载和私有目录无 DEX
- 记录公开入口的优势，以及早期签名绑定解密和原应用工厂委托两个生产阻塞项

## 验证

- 两个变体 Java 编译通过
- API 35 OnePlus 5 真机对照通过
- Manifest 确认只有工厂变体声明 `appComponentFactory`
- `bash -n tests/scripts/run-memory-loader-probe.sh`
- `git diff --check`