### PR TITLE
test: 验证原应用组件工厂委托

### DIFF
--- a/docs/design/runtime-security.md
+++ b/docs/design/runtime-security.md
@@ -315,12 +315,14 @@ BootClassLoader
 
 两种变体均在主进程和远程 Service 进程通过真实 Application、Provider、Activity、Service、跨 DEX 引用、APK 内 Native 库、GC 后延迟首次加载和私有目录无 DEX 检查。公开工厂入口由系统在 Application Context 初始化和任何应用组件实例化前调用，加载器时序与框架契约更明确，因此作为下一阶段首选；反射路径只保留为对照和止损依据，不进入正式实现。
 
-公开入口仍有两个生产阻塞项：
+公开入口最初识别出两个生产阻塞项：
 
 - 回调只有默认 ClassLoader 与 `ApplicationInfo`，尚无可用 `Context`。当前 DEXB v5 解密必须通过 `Context` 读取设备实际签名，不能原样前移；必须先设计不降低签名绑定强度的早期证书读取边界。
 - 原应用可能声明 AndroidX 或自定义 `AppComponentFactory`。壳工厂不能直接覆盖其 Application、Activity、Service、Receiver 和 Provider 实例化语义；必须验证加载业务 DEX 后的安全委托方案，并处理委托工厂创建失败和递归配置。
 
-这两个阻塞项未通过前，不把工厂探针接入正式 Stub，也不开放 `memory_dex` 能力字段。
+2026-07-30 已在工厂变体中增加载荷侧自定义工厂：壳工厂创建业务加载器后，由该加载器创建原工厂；真实 Application 由壳 Application 主动通过原工厂创建，Provider、Activity、Receiver 和远程进程 Service 则由系统回调壳工厂后转发。五类组件的原工厂标记与实际生命周期标记均通过，证明委托机制在最小框架链路中可行。
+
+正式接入仍需把原工厂类名以独立元数据保存，区分“原应用未声明工厂”、AndroidX 工厂、自定义工厂和错误地指回壳工厂的递归配置；委托创建失败必须失败关闭，不能静默退回默认工厂。无 `Context` 阶段的签名绑定解密仍是进入正式 Stub 前的主要阻塞项。在这些边界完成前，不开放 `memory_dex` 能力字段。
 
 ## 任务阶段与版本规划
 

--- a/docs/process/roadmap.md
+++ b/docs/process/roadmap.md
@@ -61,7 +61,7 @@
 | 认证缓存与资源能力 | `alpha.1` 候选完成 | 摘要、原子重建、协议握手、异常缓存自动回归及低版本运行回归已完成 | 发布 `alpha.1` 后收集兼容反馈，不阻塞后续 `alpha.2` 开发 |
 | Root 策略与内存 DEX 实验 | `alpha.2` 已发布 | GUI、核心、Manifest、双资源与兼容/严格策略链路已接通；普通真机和 LineageOS ADB Root 已完成双向回归。API 29+ 原加载器内存注入实验已止损，不合入运行代码 | 已进入 Beta 功能冻结；替换 ClassLoader 方案留待后续独立评估 |
 | `1.3.0` 功能冻结与完整回归 | 已完成 | 全部单元测试、双资源、Stub DEX 指标、端到端加固、普通/Root 双向策略、缓存篡改重建、私有目录隔离和启动耗时均已验证 | 正式版后只在补丁版本处理可复现缺陷，不再改变协议和默认行为 |
-| `1.4.0` 替换 ClassLoader 原型 | 进行中 | API 35 上反射替换与公开 `AppComponentFactory` 入口均通过双进程、四类组件、GC 后延迟加载、APK 内 Native 库和私有目录无 DEX 验证；公开入口作为首选，下一步解决无 Context 时的签名绑定解密和原应用工厂委托，再补齐正式 Stub Native、ARouter、Android 9、split、Instrumentation 和回退 | 隔离夹具不进入正式 Stub、GUI 或资源包；完整门槛通过后才发布 `alpha.1` |
+| `1.4.0` 替换 ClassLoader 原型 | 进行中 | API 35 上反射替换与公开 `AppComponentFactory` 入口均通过双进程、五类组件、GC 后延迟加载、APK 内 Native 库和私有目录无 DEX验证；原应用自定义工厂的 Application 与其余组件委托也已通过。公开入口作为首选，下一步解决无 Context 时的签名绑定解密，再补齐正式元数据、Stub Native、ARouter、Android 9、split、Instrumentation 和回退 | 隔离夹具不进入正式 Stub、GUI 或资源包；完整门槛通过后才发布 `alpha.1` |
 
 用户诊断中的低风险静态预检可以按真实反馈独立插入，不必等待整条安全主线完成；但不得与高风险壳加载改动混在同一提交或候选版本中。
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -40,7 +40,7 @@ ENVIRONMENT_POLICY=strict EXPECT_PROTECTED_REJECTION=1 RUN_DEVICE_TEST=1 \
 bash tests/scripts/run-memory-loader-probe.sh
 ```
 
-脚本会依次安装两个变体。两者都必须确认主进程与远程 Service 进程分别创建业务加载器，Application、Provider、Activity、Service 与第二 DEX 类均正常创建，APK 内 Native 库可以通过业务类加载，并且 GC 后仍可首次访问延迟类；应用私有目录不得生成完整 DEX 文件。该结果只证明最小框架链路可行，不代表早期签名绑定解密、原应用工厂委托、ARouter、系统共享库、覆盖安装或生产回退已经通过。
+脚本会依次安装两个变体。两者都必须确认主进程与远程 Service 进程分别创建业务加载器，Application、Provider、Activity、Service、Receiver 与第二 DEX 类均正常创建，APK 内 Native 库可以通过业务类加载，并且 GC 后仍可首次访问延迟类；应用私有目录不得生成完整 DEX 文件。工厂变体还会验证载荷中的原应用工厂收到五类组件的实例化回调。该结果只证明最小框架链路可行，不代表早期签名绑定解密、正式工厂元数据、ARouter、系统共享库、覆盖安装或生产回退已经通过。
 
 ## Android 4.4 Native 加载探针
 

--- a/tests/fixtures/android-memory-loader-probe/app/src/main/AndroidManifest.xml
+++ b/tests/fixtures/android-memory-loader-probe/app/src/main/AndroidManifest.xml
@@ -23,5 +23,8 @@
             android:name="dev.mocika.shield.memorypayload.PayloadProvider"
             android:authorities="dev.mocika.shield.memoryprobe.payload"
             android:exported="false" />
+        <receiver
+            android:name="dev.mocika.shield.memorypayload.PayloadReceiver"
+            android:exported="false" />
     </application>
 </manifest>

--- a/tests/fixtures/android-memory-loader-probe/app/src/main/java/dev/mocika/shield/memoryprobe/ProbeAppComponentFactory.java
+++ b/tests/fixtures/android-memory-loader-probe/app/src/main/java/dev/mocika/shield/memoryprobe/ProbeAppComponentFactory.java
@@ -1,21 +1,88 @@
 package dev.mocika.shield.memoryprobe;
 
 import android.app.AppComponentFactory;
+import android.app.Activity;
+import android.app.Application;
+import android.app.Service;
+import android.content.BroadcastReceiver;
+import android.content.ContentProvider;
+import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.util.Log;
 
 /** 使用系统公开入口创建探针业务加载器，不进入正式壳。 */
 public final class ProbeAppComponentFactory extends AppComponentFactory {
     private static final String TAG = "MOCIKA_MEMORY_PROBE";
+    private static final String PROBE_APPLICATION =
+            "dev.mocika.shield.memoryprobe.ProbeApplication";
+    private static final String ORIGINAL_FACTORY =
+            "dev.mocika.shield.memorypayload.PayloadAppComponentFactory";
+    private static ProbeAppComponentFactory activeFactory;
+
+    private AppComponentFactory originalFactory;
 
     @Override
     public ClassLoader instantiateClassLoader(ClassLoader defaultLoader, ApplicationInfo info) {
         try {
             ClassLoader loader = MemoryPayloadLoader.create(info, defaultLoader);
+            originalFactory = (AppComponentFactory) loader.loadClass(ORIGINAL_FACTORY)
+                    .getDeclaredConstructor().newInstance();
+            activeFactory = this;
             Log.i(TAG, "FACTORY_LOADER_CREATED");
+            Log.i(TAG, "FACTORY_DELEGATE_READY");
             return loader;
         } catch (Exception error) {
             throw new RuntimeException("MEMORY_PROBE_FACTORY_INIT", error);
         }
+    }
+
+    static Application instantiateOriginalApplication(ClassLoader loader, String className)
+            throws Exception {
+        ProbeAppComponentFactory factory = activeFactory;
+        if (factory == null) {
+            return (Application) loader.loadClass(className).getDeclaredConstructor().newInstance();
+        }
+        return factory.requireDelegate().instantiateApplication(loader, className);
+    }
+
+    @Override
+    public Application instantiateApplication(ClassLoader loader, String className)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        if (PROBE_APPLICATION.equals(className)) {
+            return super.instantiateApplication(loader, className);
+        }
+        return requireDelegate().instantiateApplication(loader, className);
+    }
+
+    @Override
+    public Activity instantiateActivity(ClassLoader loader, String className, Intent intent)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        return requireDelegate().instantiateActivity(loader, className, intent);
+    }
+
+    @Override
+    public Service instantiateService(ClassLoader loader, String className, Intent intent)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        return requireDelegate().instantiateService(loader, className, intent);
+    }
+
+    @Override
+    public BroadcastReceiver instantiateReceiver(
+            ClassLoader loader, String className, Intent intent)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        return requireDelegate().instantiateReceiver(loader, className, intent);
+    }
+
+    @Override
+    public ContentProvider instantiateProvider(ClassLoader loader, String className)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        return requireDelegate().instantiateProvider(loader, className);
+    }
+
+    private AppComponentFactory requireDelegate() {
+        if (originalFactory == null) {
+            throw new IllegalStateException("MEMORY_PROBE_FACTORY_DELEGATE_MISSING");
+        }
+        return originalFactory;
     }
 }

--- a/tests/fixtures/android-memory-loader-probe/app/src/main/java/dev/mocika/shield/memoryprobe/ProbeApplication.java
+++ b/tests/fixtures/android-memory-loader-probe/app/src/main/java/dev/mocika/shield/memoryprobe/ProbeApplication.java
@@ -78,8 +78,8 @@ public final class ProbeApplication extends Application {
         if (className == null || className.isEmpty()) {
             throw new IllegalStateException("MEMORY_PROBE_REAL_APP_NAME_MISSING");
         }
-        Application application = (Application) loader.loadClass(className)
-                .getDeclaredConstructor().newInstance();
+        Application application = ProbeAppComponentFactory.instantiateOriginalApplication(
+                loader, className);
         Method attach = Application.class.getDeclaredMethod("attach", Context.class);
         attach.setAccessible(true);
         attach.invoke(application, base);

--- a/tests/fixtures/android-memory-loader-probe/payload-main/src/main/java/dev/mocika/shield/memorypayload/PayloadActivity.java
+++ b/tests/fixtures/android-memory-loader-probe/payload-main/src/main/java/dev/mocika/shield/memorypayload/PayloadActivity.java
@@ -22,6 +22,7 @@ public final class PayloadActivity extends Activity {
         view.setText("MEMORY_DEX_OK");
         setContentView(view);
         startService(new Intent(this, PayloadService.class));
+        sendBroadcast(new Intent(this, PayloadReceiver.class));
         Log.i("MOCIKA_MEMORY_PROBE", "ACTIVITY_OK:" + SecondaryMarker.value()
                 + ":" + nativeMarker());
         System.gc();

--- a/tests/fixtures/android-memory-loader-probe/payload-main/src/main/java/dev/mocika/shield/memorypayload/PayloadAppComponentFactory.java
+++ b/tests/fixtures/android-memory-loader-probe/payload-main/src/main/java/dev/mocika/shield/memorypayload/PayloadAppComponentFactory.java
@@ -1,0 +1,51 @@
+package dev.mocika.shield.memorypayload;
+
+import android.app.Activity;
+import android.app.AppComponentFactory;
+import android.app.Application;
+import android.app.Service;
+import android.content.BroadcastReceiver;
+import android.content.ContentProvider;
+import android.content.Intent;
+import android.util.Log;
+
+/** 模拟原应用已有的自定义组件工厂。 */
+public final class PayloadAppComponentFactory extends AppComponentFactory {
+    private static final String TAG = "MOCIKA_MEMORY_PROBE";
+
+    @Override
+    public Application instantiateApplication(ClassLoader loader, String className)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        Log.i(TAG, "ORIGINAL_FACTORY_APPLICATION");
+        return super.instantiateApplication(loader, className);
+    }
+
+    @Override
+    public Activity instantiateActivity(ClassLoader loader, String className, Intent intent)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        Log.i(TAG, "ORIGINAL_FACTORY_ACTIVITY");
+        return super.instantiateActivity(loader, className, intent);
+    }
+
+    @Override
+    public Service instantiateService(ClassLoader loader, String className, Intent intent)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        Log.i(TAG, "ORIGINAL_FACTORY_SERVICE");
+        return super.instantiateService(loader, className, intent);
+    }
+
+    @Override
+    public BroadcastReceiver instantiateReceiver(
+            ClassLoader loader, String className, Intent intent)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        Log.i(TAG, "ORIGINAL_FACTORY_RECEIVER");
+        return super.instantiateReceiver(loader, className, intent);
+    }
+
+    @Override
+    public ContentProvider instantiateProvider(ClassLoader loader, String className)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        Log.i(TAG, "ORIGINAL_FACTORY_PROVIDER");
+        return super.instantiateProvider(loader, className);
+    }
+}

--- a/tests/fixtures/android-memory-loader-probe/payload-main/src/main/java/dev/mocika/shield/memorypayload/PayloadReceiver.java
+++ b/tests/fixtures/android-memory-loader-probe/payload-main/src/main/java/dev/mocika/shield/memorypayload/PayloadReceiver.java
@@ -1,0 +1,13 @@
+package dev.mocika.shield.memorypayload;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+public final class PayloadReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        Log.i("MOCIKA_MEMORY_PROBE", "RECEIVER_OK");
+    }
+}

--- a/tests/scripts/run-memory-loader-probe.sh
+++ b/tests/scripts/run-memory-loader-probe.sh
@@ -50,6 +50,7 @@ MEMORY_PROBE_ASSETS="$ASSET_DIR" "$GRADLE" -p "$PROJECT_DIR" \
 run_probe() {
   local mode="$1"
   local expected_loader_marker="$2"
+  local expect_factory_delegate="$3"
   local apk="$PROJECT_DIR/app/build/outputs/apk/$mode/debug/app-$mode-debug.apk"
 
   "${ADB[@]}" uninstall "$PACKAGE" >/dev/null 2>&1 || true
@@ -69,6 +70,15 @@ run_probe() {
     fi
   done
 
+  if [[ "$expect_factory_delegate" == "true" ]]; then
+    for marker in FACTORY_DELEGATE_READY ORIGINAL_FACTORY_APPLICATION ORIGINAL_FACTORY_PROVIDER ORIGINAL_FACTORY_ACTIVITY ORIGINAL_FACTORY_SERVICE ORIGINAL_FACTORY_RECEIVER RECEIVER_OK; do
+      if ! grep -Fq "$marker" <<<"$logs"; then
+        echo "$mode 原应用工厂委托缺少标记：$marker" >&2
+        exit 1
+      fi
+    done
+  fi
+
   local loader_process_count
   loader_process_count="$(grep -F "$expected_loader_marker" <<<"$logs" | awk '{print $3}' | sort -u | wc -l | tr -d ' ')"
   if (( loader_process_count < 2 )); then
@@ -85,7 +95,7 @@ run_probe() {
   fi
 }
 
-run_probe reflection "LOADER_READY:REFLECTION"
-run_probe factory "LOADER_READY:FACTORY"
+run_probe reflection "LOADER_READY:REFLECTION" false
+run_probe factory "LOADER_READY:FACTORY" true
 
 echo "API $SDK_INT 两种 ClassLoader 入口的内存双 DEX 探针均通过，应用私有目录未发现 DEX 文件"


### PR DESCRIPTION
## 变更内容

- 在内存 DEX 工厂探针中加载并持有载荷侧原应用组件工厂
- 壳工厂转发 Application、Activity、Service、Provider 和 Receiver 实例化
- 增加 Receiver 生命周期与五类原工厂回调断言
- 记录委托机制的真机结论及正式元数据边界

## 验证

- API 35 OnePlus 5 主进程和远程进程真机通过
- 原工厂收到五类组件实例化回调
- 双 DEX、Native、GC 后延迟加载与私有目录无 DEX 继续通过
- `bash -n tests/scripts/run-memory-loader-probe.sh`
- `git diff --check`