### PR TITLE
test: 补齐内存DEX关键系统矩阵

### DIFF
--- a/docs/design/runtime-security.md
+++ b/docs/design/runtime-security.md
@@ -302,7 +302,7 @@ BootClassLoader
 - Android 9 系统共享库和 AppComponentFactory
 - split APK、Instrumentation 和厂商 ClassLoader
 - 首次安装、清除数据、同签名覆盖安装和崩溃后文件模式重启回退
-- API 29、API 35 16 KB、API 36 的性能和内存矩阵
+- 更广泛厂商真机的性能和内存矩阵
 
 探针通过不改变正式能力：`metadata.json` 继续保持 `memory_dex: false`，标准/API 19 资源与 GUI 均不接入该路径。
 
@@ -323,6 +323,21 @@ BootClassLoader
 2026-07-30 已在工厂变体中增加载荷侧自定义工厂：壳工厂创建业务加载器后，由该加载器创建原工厂；真实 Application 由壳 Application 主动通过原工厂创建，Provider、Activity、Receiver 和远程进程 Service 则由系统回调壳工厂后转发。五类组件的原工厂标记与实际生命周期标记均通过，证明委托机制在最小框架链路中可行。
 
 正式接入仍需把原工厂类名以独立元数据保存，区分“原应用未声明工厂”、AndroidX 工厂、自定义工厂和错误地指回壳工厂的递归配置；委托创建失败必须失败关闭，不能静默退回默认工厂。无 `Context` 阶段的签名绑定解密仍是进入正式 Stub 前的主要阻塞项。在这些边界完成前，不开放 `memory_dex` 能力字段。
+
+#### API 29～36 关键版本矩阵
+
+2026-07-30 使用相同探针完成首轮关键系统节点验证：
+
+| 环境 | 页大小 | 结果 | 覆盖范围 |
+|------|--------|------|----------|
+| API 29 ARM64 模拟器 | 4 KB | 通过 | 两种入口、双进程、五类组件、原工厂委托、双 DEX、Native、GC 延迟加载、私有目录无 DEX |
+| API 35 ARM64 16 KB 模拟器 | 16 KB | 通过 | 同上；确认 APK 内 Native 库可在 16 KB 环境加载 |
+| API 36 ARM64 模拟器 | 4 KB | 通过 | 同上 |
+| API 35 OnePlus 5 真机 | 4 KB | 通过 | 同上 |
+
+API 35 16 KB 首次运行暴露测试 `libmemoryprobe.so` 只有 GNU 哈希表且 ELF `LOAD` 段仍按 4 KB 对齐，系统在 Native 加载阶段拒绝启动。探针随后显式生成 SysV/GNU 双哈希表并将最大页大小设为 16 KB，复验通过。该问题属于测试 Native 产物，不是内存 DEX 加载失败；修正参数保留为探针自身的 16 KB 前置条件。
+
+该矩阵证明公开工厂入口和反射对照在 API 29 最低边界、API 35 16 KB 与 API 36 模拟器上具备一致的最小运行行为，但仍不能替代厂商真机、正式 Stub Native、真实 APK 与性能验证。
 
 ## 任务阶段与版本规划
 

--- a/docs/process/roadmap.md
+++ b/docs/process/roadmap.md
@@ -61,7 +61,7 @@
 | 认证缓存与资源能力 | `alpha.1` 候选完成 | 摘要、原子重建、协议握手、异常缓存自动回归及低版本运行回归已完成 | 发布 `alpha.1` 后收集兼容反馈，不阻塞后续 `alpha.2` 开发 |
 | Root 策略与内存 DEX 实验 | `alpha.2` 已发布 | GUI、核心、Manifest、双资源与兼容/严格策略链路已接通；普通真机和 LineageOS ADB Root 已完成双向回归。API 29+ 原加载器内存注入实验已止损，不合入运行代码 | 已进入 Beta 功能冻结；替换 ClassLoader 方案留待后续独立评估 |
 | `1.3.0` 功能冻结与完整回归 | 已完成 | 全部单元测试、双资源、Stub DEX 指标、端到端加固、普通/Root 双向策略、缓存篡改重建、私有目录隔离和启动耗时均已验证 | 正式版后只在补丁版本处理可复现缺陷，不再改变协议和默认行为 |
-| `1.4.0` 替换 ClassLoader 原型 | 进行中 | API 35 上反射替换与公开 `AppComponentFactory` 入口均通过双进程、五类组件、GC 后延迟加载、APK 内 Native 库和私有目录无 DEX验证；原应用自定义工厂的 Application 与其余组件委托也已通过。公开入口作为首选，下一步解决无 Context 时的签名绑定解密，再补齐正式元数据、Stub Native、ARouter、Android 9、split、Instrumentation 和回退 | 隔离夹具不进入正式 Stub、GUI 或资源包；完整门槛通过后才发布 `alpha.1` |
+| `1.4.0` 替换 ClassLoader 原型 | 进行中 | API 29、API 35 16 KB、API 36 模拟器与 API 35 真机上，反射和公开 `AppComponentFactory` 两种入口均通过双进程、五类组件、原工厂委托、双 DEX、Native、GC 延迟加载和私有目录无 DEX 验证。公开入口作为首选，下一步解决无 Context 时的签名绑定解密，再补齐正式元数据、Stub Native、ARouter、Android 9、split、Instrumentation 和回退 | 隔离夹具不进入正式 Stub、GUI 或资源包；完整门槛通过后才发布 `alpha.1` |
 
 用户诊断中的低风险静态预检可以按真实反馈独立插入，不必等待整条安全主线完成；但不得与高风险壳加载改动混在同一提交或候选版本中。
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -42,6 +42,8 @@ bash tests/scripts/run-memory-loader-probe.sh
 
 脚本会依次安装两个变体。两者都必须确认主进程与远程 Service 进程分别创建业务加载器，Application、Provider、Activity、Service、Receiver 与第二 DEX 类均正常创建，APK 内 Native 库可以通过业务类加载，并且 GC 后仍可首次访问延迟类；应用私有目录不得生成完整 DEX 文件。工厂变体还会验证载荷中的原应用工厂收到五类组件的实例化回调。该结果只证明最小框架链路可行，不代表早期签名绑定解密、正式工厂元数据、ARouter、系统共享库、覆盖安装或生产回退已经通过。
 
+当前已通过 API 29 ARM64 4 KB、API 35 ARM64 16 KB、API 36 ARM64 4 KB 模拟器和 API 35 ARM64 真机。探针 Native 库显式生成 SysV/GNU 双哈希表并按 16 KB 最大页大小链接，防止测试资产自身在 16 KB 系统中先于内存 DEX 验证失败。
+
 ## Android 4.4 Native 加载探针
 
 `fixtures/android-api19-native-probe` 只负责验证 NDK r25c、Rust 1.77.2、API 19 构建的生产 `libmocikashield.so` 能够被 Android 4.4 的动态链接器加载，并成功执行 `JNI_OnLoad` 动态注册。它不包含 DEX 解密、Dalvik 注入或业务兼容逻辑。

--- a/tests/fixtures/android-memory-loader-probe/app/src/main/cpp/CMakeLists.txt
+++ b/tests/fixtures/android-memory-loader-probe/app/src/main/cpp/CMakeLists.txt
@@ -2,3 +2,6 @@ cmake_minimum_required(VERSION 3.22.1)
 project(memoryprobe)
 
 add_library(memoryprobe SHARED memoryprobe.cpp)
+target_link_options(memoryprobe PRIVATE
+    "-Wl,--hash-style=both"
+    "-Wl,-z,max-page-size=16384")

--- a/tests/scripts/run-memory-loader-probe.sh
+++ b/tests/scripts/run-memory-loader-probe.sh
@@ -24,6 +24,7 @@ if [[ ! "$SDK_INT" =~ ^[0-9]+$ ]] || (( SDK_INT < 29 )); then
   echo "内存 DEX 加载探针只支持 API 29 及以上设备，当前 API：${SDK_INT:-未知}" >&2
   exit 1
 fi
+PAGE_SIZE="$("${ADB[@]}" shell getconf PAGE_SIZE | tr -d '\r')"
 
 ANDROID_SDK_DIR="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}"
 if [[ -z "$ANDROID_SDK_DIR" ]]; then
@@ -98,4 +99,4 @@ run_probe() {
 run_probe reflection "LOADER_READY:REFLECTION" false
 run_probe factory "LOADER_READY:FACTORY" true
 
-echo "API $SDK_INT 两种 ClassLoader 入口的内存双 DEX 探针均通过，应用私有目录未发现 DEX 文件"
+echo "API $SDK_INT（页大小 $PAGE_SIZE）两种 ClassLoader 入口的内存双 DEX 探针均通过，应用私有目录未发现 DEX 文件"


### PR DESCRIPTION
## 变更内容

- 补齐 API 29、API 35 16 KB 和 API 36 的内存 DEX 双入口回归记录
- 为探针 Native 库补充 SysV/GNU 双哈希表和 16 KB ELF 段对齐
- 在探针结果中输出设备实际页大小
- 同步运行时设计、路线图与测试说明

## 验证结果

- API 29 ARM64 模拟器，4 KB：通过
- API 35 ARM64 模拟器，16 KB：通过
- API 36 ARM64 模拟器，4 KB：通过
- API 35 OnePlus 5 真机，4 KB：此前已通过
- 每个节点均覆盖两种入口、双进程、五类组件、原工厂委托、双 DEX、Native、GC 延迟加载与私有目录无 DEX
- ELF 动态段同时包含 `HASH` 与 `GNU_HASH`，加载段对齐为 `0x4000`