### PR TITLE
docs: 统一项目双许可证授权

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,180 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other transformations
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as submitted to the Licensor for inclusion
+      in the Work by the copyright owner or by an individual or Legal Entity
+      authorized to submit on behalf of the copyright owner. For the purposes
+      of this definition, "submit" means any form of electronic, verbal, or
+      written communication sent to the Licensor or its representatives,
+      including but not limited to communication on electronic mailing lists,
+      source forums, and issue tracking systems that are managed by, or on
+      behalf of, the Licensor for the purpose of tracking and reporting.
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and included
+      within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by the combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a cross-claim
+      or counterclaim in a lawsuit) alleging that the Work or any
+      Contribution embodied within the Work constitutes direct or
+      contributory patent infringement, then any patent licenses granted to
+      You under this License for that Work shall terminate as of the date
+      such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or in addition to the
+          NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the
+      Contribution, either unilaterally or together with the Work, provided
+      your use of the Work otherwise complies with the conditions stated
+      in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any conditions of TITLE,
+      MERCHANTIBILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely
+      responsible for determining the appropriateness of using or
+      redistributing the Work and assume any risks associated with Your
+      exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (even if such Contributor has been advised of the possibility
+      of such damages).
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may offer such
+      obligations only on Your own behalf and on Your sole responsibility,
+      not on behalf of any other Contributor, and only if You agree to
+      indemnify, defend, and hold each Contributor harmless for any
+      liability incurred by, or claims asserted against, such Contributor
+      by reason of your accepting any warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 索学超及贡献者
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 MocikaDev
+Copyright (c) 2026 索学超及贡献者
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.en.md
+++ b/README.en.md
@@ -4,7 +4,7 @@
 
 [![Latest Release](https://img.shields.io/github/v/release/mocikadev/mocika-shield?style=flat-square&label=release&color=6366f1)](https://github.com/mocikadev/mocika-shield/releases/latest)
 [![CI](https://img.shields.io/github/actions/workflow/status/mocikadev/mocika-shield/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/mocikadev/mocika-shield/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/license-MIT-green?style=flat-square)](LICENSE)
+[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-green?style=flat-square)](#license)
 
 Mocika Shield is an open-source, offline Android APK hardening tool. It compresses and encrypts DEX files, then decrypts and loads them through a protected runtime stub. The goal is to raise the cost of static analysis, unauthorized repackaging, and runtime debugging—not to claim that an Android application can be made impossible to reverse engineer.
 
@@ -171,4 +171,7 @@ Diagnostic information can be copied from the application's **About** page. Revi
 
 ## License
 
-[MIT](LICENSE)
+This project is dual-licensed under **MIT OR Apache-2.0**. You may choose either license.
+
+- [MIT License](LICENSE-MIT)
+- [Apache License 2.0](LICENSE-APACHE)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![最新版本](https://img.shields.io/github/v/release/mocikadev/mocika-shield?style=flat-square&label=最新版本&color=6366f1)](https://github.com/mocikadev/mocika-shield/releases/latest)
 [![CI](https://img.shields.io/github/actions/workflow/status/mocikadev/mocika-shield/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/mocikadev/mocika-shield/actions/workflows/ci.yml)
-[![许可证](https://img.shields.io/badge/license-MIT-green?style=flat-square)](LICENSE)
+[![许可证](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-green?style=flat-square)](#许可证)
 
 对 Android APK 的 DEX 文件进行压缩加密，并在运行时通过壳程序动态解密加载，防止静态反编译与重打包攻击。
 
@@ -289,7 +289,10 @@ APK、证书、密钥库和签名密码只在本机处理，不会上传。桌�
 
 ## 许可证
 
-[MIT](LICENSE)
+本项目采用 **MIT OR Apache-2.0** 双协议授权，你可以选择其中任意一种。
+
+- [MIT 许可证](LICENSE-MIT)
+- [Apache 2.0 许可证](LICENSE-APACHE)
 
 ## 安全问题
 

--- a/apps/shield-cli/Cargo.toml
+++ b/apps/shield-cli/Cargo.toml
@@ -3,7 +3,7 @@ name = "shield-cli"
 version = "1.3.0"
 edition = "2021"
 authors = ["MocikaDev"]
-license = "MIT"
+license = "MIT OR Apache-2.0"
 description = "Mocika Shield APK 加固命令行工具"
 repository = "git@github.com:mocikadev/mocika-shield.git"
 

--- a/apps/shield-gui/package-lock.json
+++ b/apps/shield-gui/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "mocika-shield-gui",
       "version": "1.3.0",
+      "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.19",
         "@radix-ui/react-label": "^2.1.11",

--- a/apps/shield-gui/package.json
+++ b/apps/shield-gui/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mocika-shield-gui",
   "version": "1.3.0",
+  "license": "MIT OR Apache-2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/shield-gui/src-tauri/Cargo.toml
+++ b/apps/shield-gui/src-tauri/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mocika-shield"
 version = "1.3.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 publish = false
 description = "Mocika Shield APK 加固工具桌面 GUI"
 default-run = "mocika-shield"

--- a/crates/shield-core/Cargo.toml
+++ b/crates/shield-core/Cargo.toml
@@ -3,7 +3,7 @@ name = "shield-core"
 version = "1.3.0"
 edition = "2021"
 authors = ["MocikaDev"]
-license = "MIT"
+license = "MIT OR Apache-2.0"
 description = "Mocika Shield 核心加固与签名能力"
 repository = "git@github.com:mocikadev/mocika-shield.git"
 

--- a/shield-stub/compat/api19-rust/Cargo.toml
+++ b/shield-stub/compat/api19-rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mocikashield-api19"
 version = "1.3.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 build = "../../src/main/rust/build.rs"
 
 [workspace]

--- a/shield-stub/src/main/rust/Cargo.toml
+++ b/shield-stub/src/main/rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mocikashield"
 version = "1.3.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [lib]
 name = "mocikashield"


### PR DESCRIPTION
## 变更内容

- 将单一 MIT 调整为 `MIT OR Apache-2.0` 双许可证
- 与 `mocika-skills-cli`、`mocika-samsara` 的授权方式保持一致
- 版权主体标记为“索学超及贡献者”，保留历史贡献者权益
- 同步中英文 README 徽章和许可证说明
- 同步 Rust 各包与 GUI 前端包的许可证元数据

## 验证

- Cargo 全部工作区包均识别为 `MIT OR Apache-2.0`
- GUI TypeScript 类型检查通过
- Android 4.4 构建契约测试通过
- README 中不存在旧 `LICENSE` 链接