### PR TITLE
feat: 完善CLI自动化加固与签名契约

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3475,6 +3475,8 @@ dependencies = [
  "serde",
  "serde_json",
  "shield-core",
+ "tempfile",
+ "toml 0.8.2",
  "zip",
 ]
 

--- a/apps/shield-cli/Cargo.toml
+++ b/apps/shield-cli/Cargo.toml
@@ -12,7 +12,7 @@ name = "shield"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.5", features = ["derive", "cargo"] }
+clap = { version = "4.5", features = ["derive", "cargo", "env"] }
 anyhow = "1.0"
 env_logger = "0.11"
 log = "0.4"
@@ -21,3 +21,7 @@ colored = "3.1"
 shield-core = { path = "../../crates/shield-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+toml = "0.8"
+
+[dev-dependencies]
+tempfile = "3.20"

--- a/apps/shield-cli/src/args.rs
+++ b/apps/shield-cli/src/args.rs
@@ -1,0 +1,115 @@
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use std::path::PathBuf;
+
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+pub(crate) enum EnvironmentPolicyArg {
+    #[default]
+    Compatible,
+    Strict,
+}
+
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+pub(crate) enum KeystoreTypeArg {
+    #[default]
+    Jks,
+    Pkcs12,
+}
+
+#[derive(Parser)]
+#[command(
+    name = "shield",
+    version,
+    author,
+    about = "Android APK 加固工具",
+    arg_required_else_help = true
+)]
+pub(crate) struct Cli {
+    /// CLI 人工配置文件，建议命名为 shield-cli.toml。
+    #[arg(long, global = true, value_name = "FILE")]
+    pub config: Option<PathBuf>,
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum Commands {
+    Protect(ProtectArgs),
+    Sign(SignArgs),
+    CheckApk {
+        path: PathBuf,
+    },
+    CheckKeystore {
+        #[arg(long)]
+        ks: PathBuf,
+        #[arg(long)]
+        alias: String,
+        #[arg(long)]
+        ks_pass: String,
+    },
+}
+
+impl Commands {
+    pub(crate) fn machine_output(&self) -> bool {
+        match self {
+            Self::Protect(args) => args.json,
+            Self::Sign(args) => args.json,
+            Self::CheckApk { .. } | Self::CheckKeystore { .. } => true,
+        }
+    }
+}
+
+#[derive(Args, Default)]
+pub(crate) struct ProtectArgs {
+    #[arg(short, long, value_name = "APK")]
+    pub input: Option<PathBuf>,
+    #[arg(short, long, value_name = "APK")]
+    pub output: Option<PathBuf>,
+    #[arg(long, value_name = "JAR")]
+    pub apktool: Option<PathBuf>,
+    /// 内部回归测试使用的运行时资源包。
+    #[arg(long, value_name = "ZIP", hide = true)]
+    pub resources: Option<PathBuf>,
+    #[arg(long, value_name = "JAR")]
+    pub apksigner: Option<PathBuf>,
+    /// 运行时环境策略：兼容模式仅执行反调试，严格模式额外拒绝高置信 Root 环境。
+    #[arg(long, value_enum)]
+    pub environment_policy: Option<EnvironmentPolicyArg>,
+    /// 每行输出一个 JSON 事件，兼容原有 --json-progress 参数。
+    #[arg(long, alias = "json-progress")]
+    pub json: bool,
+    #[arg(short, long)]
+    pub verbose: bool,
+}
+
+#[derive(Args, Default)]
+pub(crate) struct SignArgs {
+    #[arg(short, long, value_name = "APK")]
+    pub input: Option<PathBuf>,
+    #[arg(short, long, value_name = "APK")]
+    pub output: Option<PathBuf>,
+    #[arg(long, value_name = "KEYSTORE")]
+    pub ks: Option<PathBuf>,
+    #[arg(long)]
+    pub key_alias: Option<String>,
+    /// Keystore 密码；自动化环境优先使用 MOCIKA_SHIELD_KS_PASS。
+    #[arg(long, env = "MOCIKA_SHIELD_KS_PASS", hide_env_values = true)]
+    pub ks_pass: Option<String>,
+    /// Key 密码；未提供时沿用 Keystore 密码。
+    #[arg(long, env = "MOCIKA_SHIELD_KEY_PASS", hide_env_values = true)]
+    pub key_pass: Option<String>,
+    #[arg(long, value_enum)]
+    pub ks_type: Option<KeystoreTypeArg>,
+    #[arg(long, value_name = "JAR")]
+    pub apksigner: Option<PathBuf>,
+    #[arg(long)]
+    pub v1: Option<bool>,
+    #[arg(long)]
+    pub v2: Option<bool>,
+    #[arg(long)]
+    pub v3: Option<bool>,
+    #[arg(long)]
+    pub v4: Option<bool>,
+    /// 每行输出一个 JSON 事件。
+    #[arg(long)]
+    pub json: bool,
+}

--- a/apps/shield-cli/src/cli_json.rs
+++ b/apps/shield-cli/src/cli_json.rs
@@ -15,6 +15,13 @@ pub(crate) struct ProgressEvent {
 }
 
 #[derive(Debug, Serialize)]
+pub(crate) struct ErrorEvent {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    message: String,
+}
+
+#[derive(Debug, Serialize)]
 pub(crate) struct ApkCheckOutput {
     pub already_protected: bool,
     pub is_signed: bool,
@@ -41,6 +48,14 @@ pub(crate) fn progress_event_json(step: &str, message: &str) -> String {
     .expect("序列化进度事件失败")
 }
 
+pub(crate) fn error_event_json(message: String) -> String {
+    serde_json::to_string(&ErrorEvent {
+        kind: "error",
+        message,
+    })
+    .expect("序列化 error 事件失败")
+}
+
 pub(crate) fn apk_check_json(
     already_protected: bool,
     is_signed: bool,
@@ -55,28 +70,10 @@ pub(crate) fn apk_check_json(
     .expect("序列化 APK 检查结果失败")
 }
 
-pub(crate) fn apk_check_error_json(message: String) -> String {
-    serde_json::to_string(&ApkCheckOutput {
-        already_protected: false,
-        is_signed: false,
-        cert_fingerprint: None,
-        error: Some(message),
-    })
-    .expect("序列化 APK 检查错误失败")
-}
-
 pub(crate) fn keystore_check_json(cert_fingerprint: String) -> String {
     serde_json::to_string(&KeystoreCheckOutput {
         cert_fingerprint: Some(cert_fingerprint),
         error: None,
     })
     .expect("序列化 keystore 检查结果失败")
-}
-
-pub(crate) fn keystore_check_error_json(message: String) -> String {
-    serde_json::to_string(&KeystoreCheckOutput {
-        cert_fingerprint: None,
-        error: Some(message),
-    })
-    .expect("序列化 keystore 检查错误失败")
 }

--- a/apps/shield-cli/src/commands.rs
+++ b/apps/shield-cli/src/commands.rs
@@ -7,28 +7,20 @@ use std::sync::{atomic::AtomicBool, Arc};
 use shield_core::utils::set_json_mode;
 use shield_core::{
     check_apk, extract_apk_cert_fingerprint, extract_keystore_cert_fingerprint, protect_apk,
-    EnvironmentPolicy, ProgressEvent, ProtectOptions,
+    sign_apk_with_progress, EnvironmentPolicy, KeystoreType, ProgressEvent, ProtectOptions,
+    SignOptions, SigningProgressStep, SigningVersions,
 };
 
-use crate::EnvironmentPolicyArg;
+use crate::args::{EnvironmentPolicyArg, KeystoreTypeArg};
+use crate::config::{ResolvedProtectArgs, ResolvedSignArgs};
 
-use crate::cli_json::{
-    apk_check_error_json, apk_check_json, done_event_json, keystore_check_error_json,
-    keystore_check_json, progress_event_json,
-};
+use crate::cli_json::{apk_check_json, done_event_json, keystore_check_json, progress_event_json};
 
-pub(crate) fn run_protect(
-    input: PathBuf,
-    output: PathBuf,
-    resources_path: Option<PathBuf>,
-    environment_policy: EnvironmentPolicyArg,
-    json_progress: bool,
-    verbose: bool,
-) -> Result<()> {
-    if json_progress {
+pub(crate) fn run_protect(args: ResolvedProtectArgs) -> Result<()> {
+    if args.json {
         set_json_mode(true);
     } else {
-        let level = if verbose {
+        let level = if args.verbose {
             log::LevelFilter::Debug
         } else {
             log::LevelFilter::Info
@@ -39,20 +31,20 @@ pub(crate) fn run_protect(
     }
 
     let opts = ProtectOptions {
-        input,
-        output,
-        apktool_path: None,
-        resources_path,
-        apksigner_path: None,
+        input: args.input,
+        output: args.output,
+        apktool_path: args.apktool,
+        resources_path: args.resources,
+        apksigner_path: args.apksigner,
         expected_output_cert_fingerprint: None,
-        environment_policy: match environment_policy {
+        environment_policy: match args.environment_policy {
             EnvironmentPolicyArg::Compatible => EnvironmentPolicy::Compatible,
             EnvironmentPolicyArg::Strict => EnvironmentPolicy::Strict,
         },
     };
 
     let cancel = Arc::new(AtomicBool::new(false));
-    let on_progress: Box<dyn Fn(ProgressEvent) + Send + 'static> = if json_progress {
+    let on_progress: Box<dyn Fn(ProgressEvent) + Send + 'static> = if args.json {
         Box::new(|event: ProgressEvent| {
             let step = format!("{:?}", event.step);
             println!("{}", progress_event_json(&step, &event.message));
@@ -62,23 +54,70 @@ pub(crate) fn run_protect(
         Box::new(|_| {})
     };
 
-    match protect_apk(&opts, on_progress, cancel) {
-        Ok(()) => {
-            if json_progress {
-                println!("{}", done_event_json());
-            } else {
-                println!("{}", "✓ 完成".green().bold());
-            }
-            Ok(())
+    protect_apk(&opts, on_progress, cancel)?;
+    if args.json {
+        println!("{}", done_event_json());
+    } else {
+        println!("{}", "✓ 完成".green().bold());
+    }
+    Ok(())
+}
+
+pub(crate) fn run_sign(args: ResolvedSignArgs) -> Result<()> {
+    let options = SignOptions {
+        apk_path: args.input,
+        output_path: Some(args.output),
+        keystore_path: args.keystore,
+        key_alias: args.key_alias,
+        keystore_password: args.keystore_password,
+        key_password: args.key_password,
+        apksigner_path: args.apksigner,
+        keystore_type: match args.keystore_type {
+            KeystoreTypeArg::Jks => KeystoreType::Jks,
+            KeystoreTypeArg::Pkcs12 => KeystoreType::Pkcs12,
+        },
+        signing_versions: SigningVersions {
+            v1: args.v1,
+            v2: args.v2,
+            v3: args.v3,
+            v4: args.v4,
+        },
+    };
+    sign_apk_with_progress(&options, |step| {
+        if args.json {
+            println!(
+                "{}",
+                progress_event_json(signing_step_name(step), signing_step_message(step))
+            );
+            let _ = std::io::stdout().flush();
         }
-        Err(err) => {
-            eprintln!("{err}");
-            std::process::exit(1);
-        }
+        Ok(())
+    })?;
+    if args.json {
+        println!("{}", done_event_json());
+    } else {
+        println!("{}", "✓ 签名完成".green().bold());
+    }
+    Ok(())
+}
+
+fn signing_step_name(step: SigningProgressStep) -> &'static str {
+    match step {
+        SigningProgressStep::Prepare => "prepare",
+        SigningProgressStep::Align => "align",
+        SigningProgressStep::Sign => "sign",
     }
 }
 
-pub(crate) fn run_check_apk(path: PathBuf) -> String {
+fn signing_step_message(step: SigningProgressStep) -> &'static str {
+    match step {
+        SigningProgressStep::Prepare => "准备签名环境",
+        SigningProgressStep::Align => "对齐 APK",
+        SigningProgressStep::Sign => "写入 APK 签名",
+    }
+}
+
+pub(crate) fn run_check_apk(path: PathBuf) -> Result<String> {
     match check_apk(&path, None) {
         Ok(result) => {
             let cert_fingerprint = if result.is_signed {
@@ -86,15 +125,19 @@ pub(crate) fn run_check_apk(path: PathBuf) -> String {
             } else {
                 None
             };
-            apk_check_json(result.already_protected, result.is_signed, cert_fingerprint)
+            Ok(apk_check_json(
+                result.already_protected,
+                result.is_signed,
+                cert_fingerprint,
+            ))
         }
-        Err(err) => apk_check_error_json(err.to_string()),
+        Err(err) => Err(err),
     }
 }
 
-pub(crate) fn run_check_keystore(ks: PathBuf, alias: String, ks_pass: String) -> String {
+pub(crate) fn run_check_keystore(ks: PathBuf, alias: String, ks_pass: String) -> Result<String> {
     match extract_keystore_cert_fingerprint(&ks, &alias, &ks_pass, None) {
-        Ok(fp) => keystore_check_json(fp),
-        Err(err) => keystore_check_error_json(err.to_string()),
+        Ok(fp) => Ok(keystore_check_json(fp)),
+        Err(err) => Err(err),
     }
 }

--- a/apps/shield-cli/src/config.rs
+++ b/apps/shield-cli/src/config.rs
@@ -1,0 +1,259 @@
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+use crate::args::{EnvironmentPolicyArg, KeystoreTypeArg, ProtectArgs, SignArgs};
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct CliConfig {
+    #[serde(default)]
+    schema_version: u32,
+    #[serde(default)]
+    protect: ProtectConfig,
+    #[serde(default)]
+    sign: SignConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProtectConfig {
+    input: Option<PathBuf>,
+    output: Option<PathBuf>,
+    apktool: Option<PathBuf>,
+    resources: Option<PathBuf>,
+    apksigner: Option<PathBuf>,
+    environment_policy: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SignConfig {
+    input: Option<PathBuf>,
+    output: Option<PathBuf>,
+    keystore: Option<PathBuf>,
+    key_alias: Option<String>,
+    keystore_type: Option<String>,
+    apksigner: Option<PathBuf>,
+    v1: Option<bool>,
+    v2: Option<bool>,
+    v3: Option<bool>,
+    v4: Option<bool>,
+}
+
+impl CliConfig {
+    pub(crate) fn load(path: Option<&Path>) -> Result<Self> {
+        let Some(path) = path else {
+            return Ok(Self::default());
+        };
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("读取 CLI 配置文件失败: {}", path.display()))?;
+        let mut config: Self = toml::from_str(&content)
+            .with_context(|| format!("解析 CLI 配置文件失败: {}", path.display()))?;
+        if config.schema_version != 1 {
+            bail!(
+                "不支持的 CLI 配置版本 {}，当前仅支持 1",
+                config.schema_version
+            );
+        }
+        let base = path.parent().unwrap_or_else(|| Path::new("."));
+        config.resolve_relative_paths(base);
+        Ok(config)
+    }
+
+    pub(crate) fn merge_protect(&self, args: ProtectArgs) -> Result<ResolvedProtectArgs> {
+        Ok(ResolvedProtectArgs {
+            input: required_path(args.input.or_else(|| self.protect.input.clone()), "--input")?,
+            output: required_path(
+                args.output.or_else(|| self.protect.output.clone()),
+                "--output",
+            )?,
+            apktool: args.apktool.or_else(|| self.protect.apktool.clone()),
+            resources: args.resources.or_else(|| self.protect.resources.clone()),
+            apksigner: args.apksigner.or_else(|| self.protect.apksigner.clone()),
+            environment_policy: args
+                .environment_policy
+                .or(parse_environment_policy(
+                    self.protect.environment_policy.as_deref(),
+                )?)
+                .unwrap_or_default(),
+            json: args.json,
+            verbose: args.verbose,
+        })
+    }
+
+    pub(crate) fn merge_sign(&self, args: SignArgs) -> Result<ResolvedSignArgs> {
+        let ks_pass = args
+            .ks_pass
+            .context("缺少 Keystore 密码，请使用 --ks-pass 或 MOCIKA_SHIELD_KS_PASS")?;
+        Ok(ResolvedSignArgs {
+            input: required_path(args.input.or_else(|| self.sign.input.clone()), "--input")?,
+            output: required_path(args.output.or_else(|| self.sign.output.clone()), "--output")?,
+            keystore: required_path(args.ks.or_else(|| self.sign.keystore.clone()), "--ks")?,
+            key_alias: args
+                .key_alias
+                .or_else(|| self.sign.key_alias.clone())
+                .context("缺少签名 Alias，请使用 --key-alias 或在配置文件中设置")?,
+            key_password: args.key_pass.unwrap_or_else(|| ks_pass.clone()),
+            keystore_password: ks_pass,
+            keystore_type: args
+                .ks_type
+                .or(parse_keystore_type(self.sign.keystore_type.as_deref())?)
+                .unwrap_or_default(),
+            apksigner: args.apksigner.or_else(|| self.sign.apksigner.clone()),
+            v1: args.v1.or(self.sign.v1).unwrap_or(true),
+            v2: args.v2.or(self.sign.v2).unwrap_or(true),
+            v3: args.v3.or(self.sign.v3).unwrap_or(true),
+            v4: args.v4.or(self.sign.v4).unwrap_or(false),
+            json: args.json,
+        })
+    }
+
+    fn resolve_relative_paths(&mut self, base: &Path) {
+        for path in [
+            &mut self.protect.input,
+            &mut self.protect.output,
+            &mut self.protect.apktool,
+            &mut self.protect.resources,
+            &mut self.protect.apksigner,
+            &mut self.sign.input,
+            &mut self.sign.output,
+            &mut self.sign.keystore,
+            &mut self.sign.apksigner,
+        ] {
+            if let Some(value) = path.as_mut().filter(|value| value.is_relative()) {
+                *value = base.join(&*value);
+            }
+        }
+    }
+}
+
+pub(crate) struct ResolvedProtectArgs {
+    pub input: PathBuf,
+    pub output: PathBuf,
+    pub apktool: Option<PathBuf>,
+    pub resources: Option<PathBuf>,
+    pub apksigner: Option<PathBuf>,
+    pub environment_policy: EnvironmentPolicyArg,
+    pub json: bool,
+    pub verbose: bool,
+}
+
+pub(crate) struct ResolvedSignArgs {
+    pub input: PathBuf,
+    pub output: PathBuf,
+    pub keystore: PathBuf,
+    pub key_alias: String,
+    pub keystore_password: String,
+    pub key_password: String,
+    pub keystore_type: KeystoreTypeArg,
+    pub apksigner: Option<PathBuf>,
+    pub v1: bool,
+    pub v2: bool,
+    pub v3: bool,
+    pub v4: bool,
+    pub json: bool,
+}
+
+fn required_path(value: Option<PathBuf>, flag: &str) -> Result<PathBuf> {
+    value.with_context(|| format!("缺少必填参数 {flag}，请通过命令行或配置文件提供"))
+}
+
+fn parse_environment_policy(value: Option<&str>) -> Result<Option<EnvironmentPolicyArg>> {
+    value
+        .map(|value| match value {
+            "compatible" => Ok(EnvironmentPolicyArg::Compatible),
+            "strict" => Ok(EnvironmentPolicyArg::Strict),
+            _ => bail!("environment_policy 仅支持 compatible 或 strict"),
+        })
+        .transpose()
+}
+
+fn parse_keystore_type(value: Option<&str>) -> Result<Option<KeystoreTypeArg>> {
+    value
+        .map(|value| match value.to_ascii_lowercase().as_str() {
+            "jks" => Ok(KeystoreTypeArg::Jks),
+            "pkcs12" | "p12" => Ok(KeystoreTypeArg::Pkcs12),
+            _ => bail!("keystore_type 仅支持 jks 或 pkcs12"),
+        })
+        .transpose()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn 配置相对路径以配置文件目录为基准() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_path = temp.path().join("shield-cli.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+schema_version = 1
+
+[protect]
+input = "input.apk"
+output = "out/protected.apk"
+environment_policy = "strict"
+"#,
+        )
+        .unwrap();
+
+        let config = CliConfig::load(Some(&config_path)).unwrap();
+        let resolved = config.merge_protect(ProtectArgs::default()).unwrap();
+        assert_eq!(resolved.input, temp.path().join("input.apk"));
+        assert_eq!(resolved.output, temp.path().join("out/protected.apk"));
+        assert!(matches!(
+            resolved.environment_policy,
+            EnvironmentPolicyArg::Strict
+        ));
+    }
+
+    #[test]
+    fn 命令行参数覆盖配置文件() {
+        let config: CliConfig = toml::from_str(
+            r#"
+schema_version = 1
+[protect]
+input = "config.apk"
+output = "config-out.apk"
+"#,
+        )
+        .unwrap();
+        let args = ProtectArgs {
+            input: Some(PathBuf::from("cli.apk")),
+            output: Some(PathBuf::from("cli-out.apk")),
+            ..ProtectArgs::default()
+        };
+        let resolved = config.merge_protect(args).unwrap();
+        assert_eq!(resolved.input, PathBuf::from("cli.apk"));
+        assert_eq!(resolved.output, PathBuf::from("cli-out.apk"));
+    }
+
+    #[test]
+    fn 签名密码不会从配置文件读取() {
+        let error = toml::from_str::<CliConfig>(
+            r#"
+schema_version = 1
+[sign]
+input = "input.apk"
+output = "signed.apk"
+keystore = "release.jks"
+key_alias = "release"
+keystore_password = "secret"
+"#,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn 未知配置版本会被拒绝() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_path = temp.path().join("shield-cli.toml");
+        std::fs::write(&config_path, "schema_version = 2\n").unwrap();
+        let error = CliConfig::load(Some(&config_path)).unwrap_err();
+        assert!(error.to_string().contains("当前仅支持 1"));
+    }
+}

--- a/apps/shield-cli/src/main.rs
+++ b/apps/shield-cli/src/main.rs
@@ -1,90 +1,41 @@
 use anyhow::Result;
-use clap::{Parser, Subcommand, ValueEnum};
-use std::path::PathBuf;
+use clap::Parser;
 
+mod args;
 mod cli_json;
 mod commands;
+mod config;
 
-use commands::{run_check_apk, run_check_keystore, run_protect};
+use args::{Cli, Commands};
+use cli_json::error_event_json;
+use commands::{run_check_apk, run_check_keystore, run_protect, run_sign};
+use config::CliConfig;
 
-#[derive(Clone, Copy, Default, ValueEnum)]
-enum EnvironmentPolicyArg {
-    #[default]
-    Compatible,
-    Strict,
-}
-
-#[derive(Parser)]
-#[command(
-    name = "shield",
-    version,
-    author,
-    about = "Android APK 加固工具",
-    arg_required_else_help = true
-)]
-struct Cli {
-    #[command(subcommand)]
-    command: Commands,
-}
-
-#[derive(Subcommand)]
-enum Commands {
-    Protect {
-        #[arg(short, long, value_name = "APK")]
-        input: PathBuf,
-        #[arg(short, long, value_name = "APK")]
-        output: PathBuf,
-        /// 内部回归测试使用的运行时资源包。
-        #[arg(long, value_name = "ZIP", hide = true)]
-        resources: Option<PathBuf>,
-        /// 运行时环境策略：兼容模式仅执行反调试，严格模式额外拒绝高置信 Root 环境。
-        #[arg(long, value_enum, default_value_t = EnvironmentPolicyArg::Compatible)]
-        environment_policy: EnvironmentPolicyArg,
-        #[arg(long)]
-        json_progress: bool,
-        #[arg(short, long)]
-        verbose: bool,
-    },
-    CheckApk {
-        path: PathBuf,
-    },
-    CheckKeystore {
-        #[arg(long)]
-        ks: PathBuf,
-        #[arg(long)]
-        alias: String,
-        #[arg(long)]
-        ks_pass: String,
-    },
-}
-
-fn main() -> Result<()> {
+fn main() {
     let cli = Cli::parse();
+    let machine_output = cli.command.machine_output();
+    if let Err(error) = execute(cli) {
+        if machine_output {
+            println!("{}", error_event_json(format!("{error:#}")));
+        } else {
+            eprintln!("{error:#}");
+        }
+        std::process::exit(1);
+    }
+}
+
+fn execute(cli: Cli) -> Result<()> {
+    let config = CliConfig::load(cli.config.as_deref())?;
 
     match cli.command {
-        Commands::Protect {
-            input,
-            output,
-            resources,
-            environment_policy,
-            json_progress,
-            verbose,
-        } => run_protect(
-            input,
-            output,
-            resources,
-            environment_policy,
-            json_progress,
-            verbose,
-        )?,
-
+        Commands::Protect(args) => run_protect(config.merge_protect(args)?)?,
+        Commands::Sign(args) => run_sign(config.merge_sign(args)?)?,
         Commands::CheckApk { path } => {
-            let result = run_check_apk(path);
+            let result = run_check_apk(path)?;
             println!("{result}");
         }
-
         Commands::CheckKeystore { ks, alias, ks_pass } => {
-            let result = run_check_keystore(ks, alias, ks_pass);
+            let result = run_check_keystore(ks, alias, ks_pass)?;
             println!("{result}");
         }
     }

--- a/docs/design/toolchain-modernization.md
+++ b/docs/design/toolchain-modernization.md
@@ -22,6 +22,16 @@
 - 不在标准输出混入影响解析的调试信息；敏感数据不得进入日志。
 - 同一配置在 Linux、macOS 和 Windows 上产生语义一致的结果。
 
+当前实施状态（2026-07-31）：
+
+- `protect` 保留既有参数，并统一支持 `--json`；原 `--json-progress` 作为兼容别名保留。
+- 新增 `sign` 子命令，直接复用核心对齐与签名能力，支持 JKS/PKCS12、V1～V4 开关和自定义 `apksigner.jar`。
+- 新增版本化 `shield-cli.toml`，命令行覆盖配置，相对路径以配置文件目录为基准；未知字段和未知版本失败关闭。
+- 配置文件不接收密码字段；自动化密码通过 `MOCIKA_SHIELD_KS_PASS`、`MOCIKA_SHIELD_KEY_PASS` 或当前命令参数提供。
+- JSON 流固定使用 `progress`、`done`、`error` 三类事件；成功退出码为 `0`，失败为 `1`。
+
+该契约完成真实签名和三平台参数回归后再视为冻结；在此之前不实施 GitHub Actions 模板和 Gradle 插件。
+
 ### GitHub Actions 示例
 
 在 CLI 契约稳定后提供官方工作流示例，负责下载指定版本、校验产物、执行加固并上传构建产物。示例不得内置用户证书，也不把 keystore、密码或业务 APK 上传到项目维护者服务。

--- a/docs/process/roadmap.md
+++ b/docs/process/roadmap.md
@@ -63,6 +63,7 @@
 | `1.3.0` 功能冻结与完整回归 | 已完成 | 全部单元测试、双资源、Stub DEX 指标、端到端加固、普通/Root 双向策略、缓存篡改重建、私有目录隔离和启动耗时均已验证 | 正式版后只在补丁版本处理可复现缺陷，不再改变协议和默认行为 |
 | `1.4.0` 替换 ClassLoader 原型 | 直接缓冲与自动预算候选闭环完成，长期内存门禁未通过 | 协议 3 候选默认使用 JNI 直接缓冲区，113 MB DEX 的进程高水位下降约一份 DEX；自动预算已完成允许、64/32 位拒绝、非粘性恢复和崩溃粘性回退真机验证 | 下一步区分“启动安全预算”与“长期内存性价比策略”，继续保持标准和工控资源默认文件路径；长期 PSS 边界明确前不进入 GUI 或 Alpha 集成版本 |
 | DEX 方法代码离线研究 | 已完成并停止产品接入 | 分层认证索引、逐 DEX 解封、真实 12 DEX 闭环和运行时路径评审均已完成；公开加载接口仍要求完整 DEX，分层协议无法消除长期完整 DEX 内存成本 | 保留测试私有研究成果，不修改 DEXB v5、Stub、CLI 或 GUI；只有出现稳定片段级公开接口或另立虚拟机专项时重新评审 |
+| CLI 自动化契约 | 进行中 | `protect`/`sign` 子命令、版本化 CLI 配置、环境变量密码、JSON 事件和退出码已实现首轮闭环 | 完成真实签名与三平台参数回归后冻结契约，再提供 GitHub Actions 示例 |
 
 用户诊断中的低风险静态预检可以按真实反馈独立插入，不必等待整条安全主线完成；但不得与高风险壳加载改动混在同一提交或候选版本中。
 
@@ -601,19 +602,21 @@ JNI 样本使用 NDK r29 构建独立 ARM64 测试库，通过 `JNI_OnLoad` 和 
 | 项 | 内容 |
 |----|------|
 | **优先级** | 高 |
-| **状态** | 待实现 |
+| **状态** | 进行中 |
 | **涉及模块** | shield-cli |
 
 **说明**：
 
-当前 CLI 只有单一隐式命令，计划改造为双子命令结构：
+CLI 已形成加固与签名双子命令结构：
 
 ```
-shield protect -i input.apk -o output.apk [--apktool <path>] [--resources <path>] [--keep-tmp]
-shield sign    -i input.apk -o output.apk --ks keystore.jks --ks-pass <pass> --key-alias <alias>
+shield protect -i input.apk -o output.apk [--apktool <path>] [--json]
+shield sign    -i input.apk -o output.apk --ks keystore.jks --key-alias <alias> [--json]
 ```
 
-同时支持 `--config <path>` 从文件读取参数，命令行优先级高于配置文件，方便 CI 复用。CLI 的人工配置必须与 GUI 自动维护的 `config.toml` 明确区分。
+`--config <path>` 从版本化 `shield-cli.toml` 读取参数，命令行优先级高于配置文件，相对路径以配置文件目录为基准。CLI 配置与 GUI 自动维护的 `config.toml` 明确分离，并禁止保存密码；CI 使用环境变量注入密码。JSON 模式输出逐行 `progress`、`done`、`error` 事件，失败使用非零退出码。
+
+当前实现已完成配置合并和错误路径单元测试，仍需使用真实 APK、JKS/PKCS12 分别完成签名闭环，并在 Linux、macOS、Windows 验证帮助、参数和路径语义后冻结自动化契约。
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -104,6 +104,63 @@ shield protect -i input.apk -o protected.apk
 shield protect -v -i input.apk -o protected.apk
 ```
 
+签名命令会先执行内置 ZIP 对齐，再调用发布包中的 `apksigner.jar`：
+
+```bash
+MOCIKA_SHIELD_KS_PASS='keystore密码' \
+MOCIKA_SHIELD_KEY_PASS='key密码' \
+shield sign \
+  -i protected.apk \
+  -o protected-signed.apk \
+  --ks release.jks \
+  --key-alias release
+```
+
+未设置 `MOCIKA_SHIELD_KEY_PASS` 时，Key 密码默认沿用 Keystore 密码。也可以使用 `--ks-pass` 和 `--key-pass` 显式传入，但自动化环境优先使用环境变量，避免密码直接出现在命令历史中。
+
+### CLI 配置文件
+
+CLI 人工配置建议固定命名为 `shield-cli.toml`，与 GUI 自动维护的 `config.toml` 完全独立。当前格式版本为 `1`：
+
+```toml
+schema_version = 1
+
+[protect]
+input = "input.apk"
+output = "build/protected.apk"
+environment_policy = "compatible"
+
+[sign]
+input = "build/protected.apk"
+output = "build/protected-signed.apk"
+keystore = "release.jks"
+key_alias = "release"
+keystore_type = "jks"
+v1 = true
+v2 = true
+v3 = true
+v4 = false
+```
+
+配置中的相对路径以配置文件所在目录为基准。命令行参数优先于配置文件：
+
+```bash
+shield --config shield-cli.toml protect
+MOCIKA_SHIELD_KS_PASS='keystore密码' shield --config shield-cli.toml sign
+shield --config shield-cli.toml protect -i another.apk -o another-protected.apk
+```
+
+配置文件不接受密码字段，密码只能通过环境变量或当前命令参数提供；CLI 不会把密码写入进度、错误或调试输出。
+
+### 机器可读输出与退出码
+
+`protect`、`sign` 增加 `--json` 后，每行输出一个独立 JSON 事件，事件类型固定为 `progress`、`done` 或 `error`。原有 `--json-progress` 继续作为 `protect --json` 的兼容别名。
+
+- 成功退出码为 `0`，并以 `done` 事件结束。
+- 参数、配置、加固、对齐或签名失败的退出码为 `1`。
+- JSON 模式下错误写入标准输出的 `error` 事件；普通模式错误写入标准错误。
+- 调试日志不会混入 JSON 标准输出。
+
 ### 完整流程
 
 加固完成后 APK 未签名，需手动签名后才能安装：
@@ -112,12 +169,10 @@ shield protect -v -i input.apk -o protected.apk
 # 1. 加固
 shield protect -i input.apk -o protected.apk
 
-# 2. 签名（使用发布包内置 apksigner；无需额外执行 zipalign）
-java -jar lib/apksigner.jar sign \
-  --ks keystore.jks \
-  --ks-key-alias alias \
-  --out protected-signed.apk \
-  protected.apk
+# 2. 签名（无需额外执行 zipalign）
+MOCIKA_SHIELD_KS_PASS='keystore密码' \
+shield sign -i protected.apk -o protected-signed.apk \
+  --ks keystore.jks --key-alias alias
 
 # 3. 安装
 adb install -r protected-signed.apk


### PR DESCRIPTION
## 变更内容

- 增加 `shield sign` 子命令，复用核心 APK 对齐与签名实现
- 增加版本化 `shield-cli.toml`，支持命令行覆盖配置和相对路径解析
- 密码仅允许通过当前参数或环境变量注入，不写入配置文件
- 统一 `protect`、`sign` 的逐行 JSON 进度、完成和错误事件
- 统一成功与失败退出码，并保留 `--json-progress` 兼容别名
- 更新使用指南、工具链设计和路线图

## 验证

- `cargo test --workspace`：184 项通过，5 项显式忽略
- `cargo clippy -p shield-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- JKS 与 PKCS12 真实签名产物均通过 `apksigner verify`
- JSON 成功、失败事件和失败退出码验证通过

## 架构边界

- 参数、配置、退出码和输出协议只位于 `apps/shield-cli`
- 加固、对齐和签名继续由 `shield-core` 负责
- 不修改 GUI 配置、证书数据库、Stub 或 DEXB 协议